### PR TITLE
feat: Enabled code highlights for code blocks

### DIFF
--- a/content/security/mkdocs.yml
+++ b/content/security/mkdocs.yml
@@ -20,3 +20,4 @@ markdown_extensions:
     - toc:
         permalink: true
     - admonition
+    - codehilite


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The code blocks were not enabled `codehilite` which is code highlighting, a little bit tired to read all plain-text code blocks. Therefore, I enabled this extension for it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
