### PR TITLE
Added OPA classic and gatekeeper policies, contstraint templates, con…

### DIFF
--- a/policies/opa/README.md
+++ b/policies/opa/README.md
@@ -1,0 +1,3 @@
+## Open Policy Agent (OPA) Policies
+
+Polices written for classic [OPA](https://github.com/open-policy-agent/opa) and OPA [Gatekeeper](https://github.com/open-policy-agent/gatekeeper)

--- a/policies/opa/classic/configmaps/0-lib.yaml
+++ b/policies/opa/classic/configmaps/0-lib.yaml
@@ -1,0 +1,77 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: library-k8s-helpers
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package lib.k8s.helpers
+
+    allowed_operations = allowed_ops {
+      allowed_ops := {"CREATE", "UPDATE"}
+    }
+
+    request_operation = op {
+      op := input.request.operation
+    }
+
+    request_metadata_labels = labels {
+      labels := input.request.object.metadata.labels
+    }
+
+    request_spec_template_metadata_labels = labels {
+      labels := input.request.object.spec.template.metadata.labels
+    }
+
+    deployment_error = e {
+      e := "DEPLOYMENT_INVALID"
+    }
+
+    deployment_containers = c {
+      c := input.request.object.spec.template.spec.containers
+    }
+
+    required_deployment_labels = l {
+      l := {"app", "owner"}
+    }
+
+    deployment_role = dr {
+      dr := input.request.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+    }
+
+    request_id = value {
+      value := sprintf("%v/%v/%v", [
+        request_namespace,
+        request_name,
+        request_kind
+      ])
+    }
+
+    request_name = value {
+      value := input.request.object.metadata.name
+    }
+
+    else = value {
+      value := "NOT_FOUND"
+    }
+
+    request_namespace = value {
+      value := input.request.object.metadata.namespace
+    }
+
+    else = value {
+      value := "NOT_FOUND"
+    }
+
+    request_kind = value {
+      value := input.request.kind.kind
+    }
+
+    else = value {
+      value := "NOT_FOUND"
+    }
+

--- a/policies/opa/classic/configmaps/1-main.yaml
+++ b/policies/opa/classic/configmaps/1-main.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-default-system-main
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package system
+
+    import data.kubernetes.admission
+
+    main = {
+      "apiVersion": "admission.k8s.io/v1beta1",
+      "kind": "AdmissionReview",
+      "response": response,
+    }
+
+    default uid = ""
+
+    uid = input.request.uid
+
+    response = {
+        "allowed": false,
+        "uid": uid,
+        "status": {
+            "reason": reason,
+        },
+    } {
+        reason = concat(", ", admission.deny)
+        reason != ""
+    }
+    else = {"allowed": true, "uid": uid}
+    
+

--- a/policies/opa/classic/configmaps/2-deployment-labels.yaml
+++ b/policies/opa/classic/configmaps/2-deployment-labels.yaml
@@ -1,0 +1,25 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-labels
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      required_labels := helpers.required_deployment_labels
+      provided_labels := {k | helpers.request_metadata_labels[k]}  # use set comprehension to construct set from input
+      missing_labels := required_labels - provided_labels # perform set difference
+      count(missing_labels) > 0
+
+      msg = sprintf("%q: %q label(s) missing. %q are required labels in the metadata element. Resource ID (ns/name/kind): %q", [helpers.deployment_error,concat(", ",missing_labels),concat(", ",required_labels),helpers.request_id])
+    }

--- a/policies/opa/classic/configmaps/3-deployment-spec-temp-labels.yaml
+++ b/policies/opa/classic/configmaps/3-deployment-spec-temp-labels.yaml
@@ -1,0 +1,25 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-spec-temp-labels
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers
+
+    deny[msg] {
+      input.request.kind.kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      required_labels := helpers.required_deployment_labels
+      provided_labels := {k | helpers.request_spec_template_metadata_labels[k]}  # use set comprehension to construct set from input
+      missing_labels := required_labels - provided_labels # perform set difference
+      count(missing_labels) > 0
+
+      msg = sprintf("%q: %q label(s) missing. %q are required labels in the spec.template.metadata.labels element. Resource ID (ns/name/kind): %q", [helpers.deployment_error,concat(", ",missing_labels),concat(", ",required_labels),helpers.request_id])
+    }

--- a/policies/opa/classic/configmaps/4-deployment-security-context.yaml
+++ b/policies/opa/classic/configmaps/4-deployment-security-context.yaml
@@ -1,0 +1,64 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-security-context
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.securityContext
+      msg = sprintf("%q: Valid securityContext element not found in %q container.  Resource ID (ns/name/kind): %q.", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      container.securityContext.privileged
+      msg = sprintf("%q: The securityContext element for %q container is privileged. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      container.securityContext.allowPrivilegeEscalation
+      msg = sprintf("%q: The securityContext element for container %q allows privilege escalation.Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.securityContext.runAsUser > 0
+      msg = sprintf("%q: The securityContext element for container %q is set to run as UID 0. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.securityContext.readOnlyRootFilesystem
+      msg = sprintf("%q: The securityContext element for container %q does not have a readonly root filesystem element.Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      container.securityContext.readOnlyRootFilesystem == false
+      msg = sprintf("%q: The securityContext element for container %q does not have a readonly root filesystem.Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+

--- a/policies/opa/classic/configmaps/5-deployment-registry-allowed.yaml
+++ b/policies/opa/classic/configmaps/5-deployment-registry-allowed.yaml
@@ -1,0 +1,36 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-registry-allowed
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      image = helpers.deployment_containers[_].image
+      not reg_matches_any(image,valid_deployment_registries_v2)
+      msg = sprintf("%q: %q image is not sourced from an authorized registry. Resource ID (ns/name/kind): %q", [helpers.deployment_error,image,helpers.request_id])
+    }
+
+    valid_deployment_registries_v2 = {registry |
+      allowed = "GOOD_REGISTRY,VERY_GOOD_REGISTRY"
+      registries = split(allowed, ",")
+      registry = registries[_]
+    }
+
+    reg_matches_any(str, patterns) {
+      reg_matches(str, patterns[_])
+    }
+
+    reg_matches(str, pattern) {
+      contains(str, pattern)
+    }

--- a/policies/opa/classic/configmaps/6-deployment-ns-role-allowed.yaml
+++ b/policies/opa/classic/configmaps/6-deployment-ns-role-allowed.yaml
@@ -1,0 +1,34 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-allowed-role-ns
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      role := helpers.deployment_role
+      namespace := helpers.request_namespace
+      not ns_roles_allowed(namespace,role)
+      msg := sprintf("%q: %q role is not allowed for the %q namespace. Resource ID (ns/name/kind): %q", [helpers.deployment_error,role,namespace,helpers.request_id])
+    }
+
+    ns_roles_allowed(n,r) {
+    	# a dictionary mapping each namespace to a set of permitted roles for that namespace
+        allowed := {
+          "prod": {"arn:aws:iam::123456789012:role/prod"},
+        	"dev": {"arn:aws:iam::123456789012:role/dev","arn:aws:iam::123456789012:role/test"},
+          "opa-test": {"arn:aws:iam::123456789012:role/test"},
+        }
+        allowed[n][r]
+    }
+    

--- a/policies/opa/classic/configmaps/7-deployment-resources.yaml
+++ b/policies/opa/classic/configmaps/7-deployment-resources.yaml
@@ -1,0 +1,72 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-resources
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources
+      msg = sprintf("%q: Valid resources element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources.limits
+      msg = sprintf("%q: Valid resources.limits element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources.limits.cpu
+      msg = sprintf("%q: Valid resources.limits.cpu element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources.limits.memory
+      msg = sprintf("%q: Valid resources.limits.memory element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources.requests
+      msg = sprintf("%q: Valid resources.requests element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources.requests.cpu
+      msg = sprintf("%q: Valid resources.requests.cpu element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      container = helpers.deployment_containers[_]
+      not container.resources.requests.memory
+      msg = sprintf("%q: Valid resources.requests.memory element not found in %q container. Resource ID (ns/name/kind): %q", [helpers.deployment_error,container.name,helpers.request_id])
+    }
+
+

--- a/policies/opa/classic/configmaps/8-deployment-latest-image-version.yaml
+++ b/policies/opa/classic/configmaps/8-deployment-latest-image-version.yaml
@@ -1,0 +1,30 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: deployment-valid-image-version
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers   
+
+    deny[msg] {
+      helpers.request_kind = "Deployment"
+      helpers.allowed_operations[helpers.request_operation]
+      image = helpers.deployment_containers[_].image
+      invalid_image_version(image)
+      msg = sprintf("%q: %q container image \"latest\" tag/version is not allowed. Resource ID (ns/name/kind): %q", [helpers.deployment_error,image,helpers.request_id])
+    }
+
+    invalid_image_version(image) {
+      not contains(image, ":")
+    }
+
+    invalid_image_version(image) {
+      contains(image, "latest")
+    }

--- a/policies/opa/classic/test-resources/0-ns.yaml
+++ b/policies/opa/classic/test-resources/0-ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opa-test
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opa-test1

--- a/policies/opa/classic/test-resources/1-ok.yaml
+++ b/policies/opa/classic/test-resources/1-ok.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/10-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/10-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: false  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/100-dep-all-fail.yaml
+++ b/policies/opa/classic/test-resources/100-dep-all-fail.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+  #  owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        #owner: jimmy
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/dev
+    spec: 
+      containers:
+      - name: test
+        image: read-only-container
+        imagePullPolicy: Always
+        #securityContext:  
+        #  allowPrivilegeEscalation: false  
+        #  runAsUser: 1000  
+        #  readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        #resources:  
+        #  limits:  
+        #    cpu: 200m  
+        #    memory: 20Mi  
+        #  requests:  
+        #    cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/11-dep-reg-allow.yaml
+++ b/policies/opa/classic/test-resources/11-dep-reg-allow.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: bad-test
+        image: BAD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      - name: good-test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/12-dep-wrong-role.yaml
+++ b/policies/opa/classic/test-resources/12-dep-wrong-role.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/dev
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/13-dep-no-role.yaml
+++ b/policies/opa/classic/test-resources/13-dep-no-role.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+      #annotations:
+      #  iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/14-dep-res.yaml
+++ b/policies/opa/classic/test-resources/14-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        #resources:  
+        #  limits:  
+        #    cpu: 200m  
+        #    memory: 20Mi  
+        #  requests:  
+        #    cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/15-dep-res.yaml
+++ b/policies/opa/classic/test-resources/15-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+        #  limits:  
+        #    cpu: 200m  
+        #    memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/16-dep-res.yaml
+++ b/policies/opa/classic/test-resources/16-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+        #    cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/17-dep-res.yaml
+++ b/policies/opa/classic/test-resources/17-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+        #    memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/18-dep-res.yaml
+++ b/policies/opa/classic/test-resources/18-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+        #  requests:  
+        #    cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/19-dep-res.yaml
+++ b/policies/opa/classic/test-resources/19-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+        #    cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/2-dep-lab.yaml
+++ b/policies/opa/classic/test-resources/2-dep-lab.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+  #  owner: jimmy
+    env: dev
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/20-dep-res.yaml
+++ b/policies/opa/classic/test-resources/20-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/3-dep-spec-temp-meta-lab.yaml
+++ b/policies/opa/classic/test-resources/3-dep-spec-temp-meta-lab.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        #owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/30-dep-latest.yaml
+++ b/policies/opa/classic/test-resources/30-dep-latest.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:latest
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/31-dep-no-ver.yaml
+++ b/policies/opa/classic/test-resources/31-dep-no-ver.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/4-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/4-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        # securityContext:  
+        #   allowPrivilegeEscalation: false  
+        #   runAsUser: 1000  
+        #   readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/5-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/5-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+        #   allowPrivilegeEscalation: false  
+        #   runAsUser: 1000  
+        #   readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/6-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/6-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: true  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/7-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/7-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+        #   runAsUser: 1000  
+        #  readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/8-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/8-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 0  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/classic/test-resources/9-dep-sec-cont.yaml
+++ b/policies/opa/classic/test-resources/9-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+        #   readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/constraint-templates/1-labels-constraint-template.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/1-labels-constraint-template.yaml
@@ -1,0 +1,117 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLabels
+        listKind: K8sRequiredLabelsList
+        plural: k8srequiredlabels
+        singular: k8srequiredlabels
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            labels:
+              type: array
+              items:
+                type: string
+            specTemplateLabels:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8srequiredlabels
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          provided := {label | helpers.review_metadata_labels[label]}
+          required := {label | label := input.parameters.labels[_]}
+          missing := required - provided
+          count(missing) > 0
+          msg := sprintf("%v: Resource missing %v metadata label(s). Required labels: %v. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,concat(", ",missing),concat(", ",required),helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          provided := {label | helpers.review_spec_template_metadata_labels[label]}
+          required := {label | label := input.parameters.specTemplateLabels[_]}
+          missing := required - provided
+          count(missing) > 0
+          msg := sprintf("%v: Resource missing %v spec.template.metadata label(s). Required labels: %v. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,concat(", ",missing),concat(", ",required),helpers.review_id])
+        }

--- a/policies/opa/gatekeeper/constraint-templates/2-dep-security-context-template.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/2-dep-security-context-template.yaml
@@ -1,0 +1,145 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdepsecuritycontext
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDepSecurityContext
+        listKind: K8sDepSecurityContextList
+        plural: k8sdepsecuritycontext
+        singular: k8sdepsecuritycontext
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          # readonly_filesystem = value {
+          #   container := deployment_containers[_]
+          #   x := container.
+          # }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepsecuritycontext
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.securityContext
+          msg := sprintf("%v: Valid securityContext element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          container.securityContext.privileged
+          msg := sprintf("%v: securityContext is privileged. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          container.securityContext.allowPrivilegeEscalation
+          msg := sprintf("%v: securityContext allows privilege escalation. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.securityContext.runAsUser
+          msg := sprintf("%v: securityContext does not contain runAsUser element. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.securityContext.runAsUser > 0
+          msg := sprintf("%v: securityContext is set to run as UID 0. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.securityContext.readOnlyRootFilesystem
+          msg := sprintf("%v: securityContext does not have a readonly root filesystem. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        # violation[{"msg": msg, "details": {}}] {
+        #   helpers.review_operation = input.parameters.allowedOps[_]
+        #   container = helpers.deployment_containers[_]
+        #   container.securityContext.readOnlyRootFilesystem == false
+        #   msg := sprintf("%v: securityContext does not have a readonly root filesystem. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        # }

--- a/policies/opa/gatekeeper/constraint-templates/3-dep-registry-template.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/3-dep-registry-template.yaml
@@ -1,0 +1,111 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdepregistry
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDepRegistry
+        listKind: K8sDepRegistryList
+        plural: k8sdepregistry
+        singular: k8sdepregistry
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            allowedRegistries:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepregistry
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          image = helpers.deployment_containers[_].image
+          not reg_matches_any(image,input.parameters.allowedRegistries)
+          msg = sprintf("%v: %v image is not sourced from an authorized registry. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,image,helpers.review_id])
+        }
+
+        reg_matches_any(str, patterns) {
+          reg_matches(str, patterns[_])
+        }
+
+        reg_matches(str, pattern) {
+          contains(str, pattern)
+        }
+

--- a/policies/opa/gatekeeper/constraint-templates/4-dep-role-ns-template.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/4-dep-role-ns-template.yaml
@@ -1,0 +1,110 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdeprolens
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDepRoleNs
+        listKind: K8sDepRoleNsList
+        plural: k8sdeprolens
+        singular: k8sdeprolens
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepregistry
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          role := helpers.deployment_role
+          namespace := helpers.review_namespace
+          not ns_roles_allowed(namespace,role)
+          msg := sprintf("%v: %v role is not allowed for the %q namespace. Resource ID (ns/name/kind): %q", [input.parameters.errMsg,role,namespace,helpers.review_id])
+        }
+
+        ns_roles_allowed(n,r) {
+          # a dictionary mapping each namespace to a set of permitted roles for that namespace
+            allowed := {
+              "prod": {"arn:aws:iam::123456789012:role/prod"},
+              "dev": {"arn:aws:iam::123456789012:role/dev","arn:aws:iam::123456789012:role/test"},
+              "opa-test": {"arn:aws:iam::123456789012:role/test"},
+            }
+            allowed[n][r]
+        }
+

--- a/policies/opa/gatekeeper/constraint-templates/5-dep-resources-template.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/5-dep-resources-template.yaml
@@ -1,0 +1,146 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdepresources
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDepResources
+        listKind: K8sDepResourcesList
+        plural: k8sdepresources
+        singular: k8sdepresources
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          # readonly_filesystem = value {
+          #   container := deployment_containers[_]
+          #   x := container.
+          # }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepsecuritycontext
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources
+          msg := sprintf("%v: Valid resources element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources.limits
+          msg := sprintf("%v: Valid resources.limits element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources.limits.cpu
+          msg := sprintf("%v: Valid resources.limits.cpu element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources.limits.memory
+          msg := sprintf("%v: Valid resources.limits.memory element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources.requests
+          msg := sprintf("%v: Valid resources.requests element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources.requests.cpu
+          msg := sprintf("%v: Valid resources.requests.cpu element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+      
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          container = helpers.deployment_containers[_]
+          not container.resources.requests.memory
+          msg := sprintf("%v: Valid resources.requests.memory element not found. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+

--- a/policies/opa/gatekeeper/constraint-templates/6-dep-latest-version-template.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/6-dep-latest-version-template.yaml
@@ -1,0 +1,107 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdeplatestversion
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDepLatestVersion
+        listKind: K8sDepLatestVersionList
+        plural: k8sdeplatestversion
+        singular: k8sdeplatestversion
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepregistry
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          image = helpers.deployment_containers[_].image
+          invalid_image_version(image)
+          msg = sprintf("%v: %v container image \"latest\" tag/version is not allowed. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,image,helpers.review_id])
+        }
+
+        invalid_image_version(image) {
+          not contains(image, ":")
+        }
+
+        invalid_image_version(image) {
+          contains(image, "latest")
+        }
+

--- a/policies/opa/gatekeeper/constraints/1-dep-labels-constraint.yaml
+++ b/policies/opa/gatekeeper/constraints/1-dep-labels-constraint.yaml
@@ -1,0 +1,16 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: deployment-labels
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    labels: ["app","owner"]
+    specTemplateLabels: ["app","env","owner"]
+    errMsg: "INVALID_DEPLOYMENT_LABELS"

--- a/policies/opa/gatekeeper/constraints/2-dep-security-context-constraint.yaml
+++ b/policies/opa/gatekeeper/constraints/2-dep-security-context-constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDepSecurityContext
+metadata:
+  name: deployment-security-context
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    errMsg: "INVALID_DEPLOYMENT_SECURITY_CONTEXT"

--- a/policies/opa/gatekeeper/constraints/3-dep-allowed-registry-constraint.yaml
+++ b/policies/opa/gatekeeper/constraints/3-dep-allowed-registry-constraint.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDepRegistry
+metadata:
+  name: deployment-allowed-registry
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    allowedRegistries: ["GOOD_REGISTRY","VERY_GOOD_REGISTRY"]
+    errMsg: "INVALID_DEPLOYMENT_REGISTRY"

--- a/policies/opa/gatekeeper/constraints/4-dep-allowed-role-ns-constraint.yaml
+++ b/policies/opa/gatekeeper/constraints/4-dep-allowed-role-ns-constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDepRoleNs
+metadata:
+  name: deployment-allowed-role-ns
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    errMsg: "INVALID_DEPLOYMENT_ROLE"

--- a/policies/opa/gatekeeper/constraints/5-dep-resources-constraint.yaml
+++ b/policies/opa/gatekeeper/constraints/5-dep-resources-constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDepResources
+metadata:
+  name: deployment-resources
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    errMsg: "INVALID_DEPLOYMENT_RESOURCES"

--- a/policies/opa/gatekeeper/constraints/6-dep-latest-version-constraint.yaml
+++ b/policies/opa/gatekeeper/constraints/6-dep-latest-version-constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDepLatestVersion
+metadata:
+  name: deployment-resources
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    errMsg: "INVALID_DEPLOYMENT_LATEST_VERSION"

--- a/policies/opa/gatekeeper/test-resources/0-ns.yaml
+++ b/policies/opa/gatekeeper/test-resources/0-ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opa-test
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opa-test1

--- a/policies/opa/gatekeeper/test-resources/1-ok.yaml
+++ b/policies/opa/gatekeeper/test-resources/1-ok.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/10-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/10-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: false  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/100-dep-all-fail.yaml
+++ b/policies/opa/gatekeeper/test-resources/100-dep-all-fail.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+  #  owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        #owner: jimmy
+        #env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/dev
+    spec: 
+      containers:
+      - name: test
+        image: read-only-container
+        imagePullPolicy: Always
+        #securityContext:  
+        #  allowPrivilegeEscalation: false  
+        #  runAsUser: 1000  
+        #  readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        #resources:  
+        #  limits:  
+        #    cpu: 200m  
+        #    memory: 20Mi  
+        #  requests:  
+        #    cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/11-dep-reg-allow.yaml
+++ b/policies/opa/gatekeeper/test-resources/11-dep-reg-allow.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: bad-test
+        image: BAD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      - name: good-test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/12-dep-wrong-role.yaml
+++ b/policies/opa/gatekeeper/test-resources/12-dep-wrong-role.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/dev
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/13-dep-no-role.yaml
+++ b/policies/opa/gatekeeper/test-resources/13-dep-no-role.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      #annotations:
+      #  iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/14-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/14-dep-res.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        #resources:  
+        #  limits:  
+        #    cpu: 200m  
+        #    memory: 20Mi  
+        #  requests:  
+        #    cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/15-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/15-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+        #  limits:  
+        #    cpu: 200m  
+        #    memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/16-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/16-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+        #    cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/17-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/17-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+        #    memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/18-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/18-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+        #  requests:  
+        #    cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/19-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/19-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+        #    cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/2-dep-lab.yaml
+++ b/policies/opa/gatekeeper/test-resources/2-dep-lab.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+  #  owner: jimmy
+    env: dev
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/20-dep-res.yaml
+++ b/policies/opa/gatekeeper/test-resources/20-dep-res.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+        #    memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/3-dep-spec-temp-meta-lab.yaml
+++ b/policies/opa/gatekeeper/test-resources/3-dep-spec-temp-meta-lab.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        #owner: jimmy
+        #env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/30-dep-latest.yaml
+++ b/policies/opa/gatekeeper/test-resources/30-dep-latest.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:latest
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/31-dep-no-ver.yaml
+++ b/policies/opa/gatekeeper/test-resources/31-dep-no-ver.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/4-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/4-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        # securityContext:  
+        #   allowPrivilegeEscalation: false  
+        #   runAsUser: 1000  
+        #   readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/5-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/5-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+        #   allowPrivilegeEscalation: false  
+        #   runAsUser: 1000  
+        #   readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/6-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/6-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: true  
+          runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/7-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/7-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+        #   runAsUser: 1000  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/8-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/8-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 0  
+          readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+

--- a/policies/opa/gatekeeper/test-resources/9-dep-sec-cont.yaml
+++ b/policies/opa/gatekeeper/test-resources/9-dep-sec-cont.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: opa-test
+  labels:
+    app: test
+    owner: jimmy
+spec:
+  selector:
+    matchLabels:
+      app: test
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: test
+        owner: jimmy
+        env: dev
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::123456789012:role/test
+    spec: 
+      containers:
+      - name: test
+        image: GOOD_REGISTRY/read-only-container:v0.0.1
+        imagePullPolicy: Always
+        securityContext:  
+          allowPrivilegeEscalation: false  
+          runAsUser: 1000  
+        #   readOnlyRootFilesystem: true  
+        ports:
+        - containerPort: 8080
+        resources:  
+          limits:  
+            cpu: 200m  
+            memory: 20Mi  
+          requests:  
+            cpu: 100m  
+            memory: 10Mi  
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+


### PR DESCRIPTION
…straints, and test resources

*Issue #, if available:* N/A

*Description of changes:* OPA policies written in Kubernetes configmaps and Gatekeeper constraints/templates, includes test Kubernetes resources to exercise policies in each scope.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
