### PR TITLE
fix typo about balance-similar-node-groups parameter

### DIFF
--- a/content/cluster-autoscaling/cluster-autoscaling.md
+++ b/content/cluster-autoscaling/cluster-autoscaling.md
@@ -185,7 +185,7 @@ Machine learning distributed training jobs benefit significantly from the minimi
 
 Ensure that:
 
-* Node group balancing is enabled by setting `balance-similar-node-groups=false`
+* Node group balancing is enabled by setting `balance-similar-node-groups=true`
 * [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) and/or [Pod Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) is used when clusters include both Regional and Zonal Node Groups.
     * Use [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to force or encourage regional pods to avoid zonal Node Groups, and vice versa.
     * If zonal pods schedule onto regional node groups, this will result in imbalanced capacity for your regional pods.

--- a/content/security/docs/cluster-autoscaling.md
+++ b/content/security/docs/cluster-autoscaling.md
@@ -185,7 +185,7 @@ Machine learning distributed training jobs benefit significantly from the minimi
 
 Ensure that:
 
-* Node group balancing is enabled by setting `balance-similar-node-groups=false`
+* Node group balancing is enabled by setting `balance-similar-node-groups=true`
 * [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) and/or [Pod Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) is used when clusters include both Regional and Zonal Node Groups.
     * Use [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to force or encourage regional pods to avoid zonal Node Groups, and vice versa.
     * If zonal pods schedule onto regional node groups, this will result in imbalanced capacity for your regional pods.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fix typo about `balance-similar-node-groups` parameter
`balance-similar-node-groups` parameter should be set to `true` to enable Node group balancing.

At line 179 in `content/cluster-autoscaling/cluster-autoscaling.md` and `content/security/docs/cluster-autoscaling.md` says
> * Node group balancing is enabled by setting `balance-similar-node-groups=true`.

But, at line 188 in `content/cluster-autoscaling/cluster-autoscaling.md` and `content/security/docs/cluster-autoscaling.md` says
> * Node group balancing is enabled by setting `balance-similar-node-groups=false`

So, it might be a typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
