### PR TITLE
Add a note on avoiding CAP_SYS_ADMIN in pods

### DIFF
--- a/content/security/docs/pods.md
+++ b/content/security/docs/pods.md
@@ -7,7 +7,7 @@ Pods have a variety of different settings that can strengthen or weaken your ove
 !!! info 
     EC2 and Fargate pods are assigned the aforementioned capabilites by default. Additionally, Linux capabilities can only be dropped from Fargate pods. 
 
-Pods that are run as privileged, inherit _all_ of the Linux capabilities associated with root on the host and should be avoided if possible.
+Pods that are run as privileged, inherit _all_ of the Linux capabilities associated with root on the host and should be avoided if possible. For all pragmatic reasons, `CAP_SYS_ADMIN` is equally privileged and should be avoided as well.
 
 Second, all Kubernetes worker nodes use an authorization mode called the node authorizer.  The node authorizer authorizes all API requests that originate from the kubelet and allows nodes to perform the following actions: 
 


### PR DESCRIPTION
I think we should warn customers to avoid using CAP_SYS_ADMIN since its an overloaded capability.

For context: https://lwn.net/Articles/486306/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
