### PR TITLE
Update the flag for the find command

### DIFF
--- a/content/security/docs/image.md
+++ b/content/security/docs/image.md
@@ -6,12 +6,12 @@ You should consider the container image as your first line of defense against an
 ### Create minimal images
 Start by removing all extraneous binaries from the container image.  If you’re using an unfamiliar image from Dockerhub, inspect the image using an application like [Dive](https://github.com/wagoodman/dive) which can show you the contents of each of the container’s layers.  Remove all binaries with the SETUID and SETGID bits as they can be used to escalate privilege and consider removing all shells and utilities like nc and curl that can be used for nefarious purposes. You can find the files with SETUID and SETGID bits with the following command:
 ```bash
-find / -perm +6000 -type f -exec ls -ld {} \;
+find / -perm /6000 -type f -exec ls -ld {} \;
 ```
     
 To remove the special permissions from these files, add the following directive to your container image:
 ```dockerfile
-RUN find / -xdev -perm +6000 -type f -exec chmod a-s {} \; || true
+RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; || true
 ```
 Colloquially, this is known as de-fanging your image. 
   


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

According to the man page of the `find` the  `-perm +mode` is depricated So I have updated the command with `-perm /mode`
```
-perm +mode
              This is no longer supported (and has been deprecated since 2005).  Use -perm /mode instead.
```
Reference
http://manpages.ubuntu.com/manpages/cosmic/en/man1/find.1.html
https://askubuntu.com/questions/1126527/invalid-mode-6000-with-find-perm


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
