### PR TITLE
Polices to detect/prevent ClusterIP services from misusing external IPs

### DIFF
--- a/policies/opa/classic/configmaps/10-clusterip-service-ext-ips.yaml
+++ b/policies/opa/classic/configmaps/10-clusterip-service-ext-ips.yaml
@@ -1,0 +1,25 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: clusterip-svc-ext-ips-allowed
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers   
+
+    deny[msg] {
+      helpers.request_kind = "Service"
+      helpers.allowed_operations[helpers.request_operation]
+      helpers.request_object.spec.type = "ClusterIP"
+      aips := helpers.allowed_ext_ips
+      ips := helpers.request_object.spec.externalIPs
+      helpers.ips_allowed(aips,ips)
+      msg = sprintf("%q: ClusterIP service external IPs are not found in the Allowed IPs list. Allowed IPs: %q, Submitted IPs: %q. Resource ID (ns/name/kind): %q", [helpers.service_error,aips,ips,helpers.request_id])
+    }
+

--- a/policies/opa/classic/configmaps/9-clusterip-service-ext-ips.yaml
+++ b/policies/opa/classic/configmaps/9-clusterip-service-ext-ips.yaml
@@ -1,0 +1,23 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: clusterip-svc-ext-ips
+  namespace: opa
+  labels:
+    app: opa
+    owner: jimmy
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package kubernetes.admission
+
+    import data.lib.k8s.helpers as helpers   
+
+    deny[msg] {
+      helpers.request_kind = "Service"
+      helpers.allowed_operations[helpers.request_operation]
+      helpers.request_object.spec.type = "ClusterIP"
+      helpers.request_object.spec.externalIPs
+      msg = sprintf("%q: ClusterIP service cannot specify externalIPs element. Resource ID (ns/name/kind): %q", [helpers.service_error,helpers.request_id])
+    }
+

--- a/policies/opa/classic/test-resources/40-clusterip-service-ext-ips.yaml
+++ b/policies/opa/classic/test-resources/40-clusterip-service-ext-ips.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hijack-dns
+  namespace: opa-test
+spec:
+  selector:
+    app: hijack-dns-server
+  ports:
+    - name: dns
+      protocol: UDP
+      port: 53
+      targetPort: 9053
+  externalIPs:
+    - 1.1.1.1
+    - 2.2.2.2
+    - 3.3.3.3
+    - 4.4.4.4

--- a/policies/opa/classic/test-resources/41-clusterip-service-ext-ips.yaml
+++ b/policies/opa/classic/test-resources/41-clusterip-service-ext-ips.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hijack-dns
+  namespace: opa-test
+spec:
+  selector:
+    app: hijack-dns-server
+  ports:
+    - name: dns
+      protocol: UDP
+      port: 53
+      targetPort: 9053
+  externalIPs:
+    - 8.8.8.8
+    - 8.8.4.4

--- a/policies/opa/gatekeeper/constraint-templates/7-svc-clusterip-ext-ips.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/7-svc-clusterip-ext-ips.yaml
@@ -1,0 +1,112 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8ssvcclusteripexternalips
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sSvcClusterIpExternalIps
+        listKind: K8sSvcClusterIpExternalIpsList
+        plural: k8ssvcclusteripexternalips
+        singular: k8ssvcclusteripexternalips
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          ips_allowed(a,x) {
+            allowedIPs := {ip | ip := a[_]}
+            externalIPs := {ip | ip := x[_]}
+            forbiddenIPs := externalIPs - allowedIPs
+            count(forbiddenIPs) > 0
+          }
+
+          review_object = o {
+            o := input.review.object
+          }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepregistry
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          helpers.review_kind = "Service"
+          helpers.review_object.spec.type = "ClusterIP"
+          helpers.review_object.spec.externalIPs
+          msg = sprintf("%v: ClusterIP service cannot specify externalIPs element. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,helpers.review_id])
+        }
+
+

--- a/policies/opa/gatekeeper/constraint-templates/8-svc-clusterip-ext-ips-allowed.yaml
+++ b/policies/opa/gatekeeper/constraint-templates/8-svc-clusterip-ext-ips-allowed.yaml
@@ -1,0 +1,119 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8ssvcclusteripexternalipsallow
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sSvcClusterIpExternalIpsAllow
+        listKind: K8sSvcClusterIpExternalIpsAllowList
+        plural: k8ssvcclusteripexternalipsallow
+        singular: k8ssvcclusteripexternalipsallow
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            allowedIps:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      libs: 
+        - |
+          package lib.k8s.helpers
+
+          allowed_operations = value {
+            value := {"CREATE", "UPDATE"}
+          }
+
+          review_operation = value {
+            value := input.review.operation
+          }
+
+          review_metadata_labels = value {
+            value := input.review.object.metadata.labels
+          }
+
+          review_spec_template_metadata_labels = value {
+            value := input.review.object.spec.template.metadata.labels
+          }
+
+          deployment_error = value {
+            value := "DEPLOYMENT_INVALID"
+          }
+
+          deployment_containers = value {
+            value := input.review.object.spec.template.spec.containers
+          }
+
+          deployment_role = value {
+            value := input.review.object.spec.template.metadata.annotations["iam.amazonaws.com/role"]
+          }
+
+          ips_allowed(a,x) {
+            allowedIPs := {ip | ip := a[_]}
+            externalIPs := {ip | ip := x[_]}
+            forbiddenIPs := externalIPs - allowedIPs
+            count(forbiddenIPs) > 0
+          }
+
+          review_object = o {
+            o := input.review.object
+          }
+
+          review_id = value {
+            value := sprintf("%v/%v/%v", [
+              review_namespace,
+              review_name,
+              review_kind
+            ])
+          }
+
+          review_name = value {
+            value := input.review.object.metadata.name
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_namespace = value {
+            value := input.review.object.metadata.namespace
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+
+          review_kind = value {
+            value := input.review.kind.kind
+          }
+
+          else = value {
+            value := "NOT_FOUND"
+          }
+      rego: |
+        package k8sdepregistry
+
+        import data.lib.k8s.helpers as helpers
+
+        violation[{"msg": msg, "details": {}}] {
+          helpers.review_operation = input.parameters.allowedOps[_]
+          helpers.review_kind = "Service"
+          helpers.review_object.spec.type = "ClusterIP"
+          helpers.review_object.spec.externalIPs
+          aips := input.parameters.allowedIps
+          ips := helpers.review_object.spec.externalIPs
+          helpers.ips_allowed(aips,ips)
+          msg = sprintf("%v: ClusterIP service external IPs are not found in the Allowed IPs list. Allowed IPs: %v, Submitted IPs: %v. Resource ID (ns/name/kind): %v", [input.parameters.errMsg,aips,ips,helpers.review_id])
+        }
+
+

--- a/policies/opa/gatekeeper/constraints/7-svc-clusterip-ext-ips.yaml
+++ b/policies/opa/gatekeeper/constraints/7-svc-clusterip-ext-ips.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sSvcClusterIpExternalIps
+metadata:
+  name: svc-clusterip-ext-ips
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Service"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    errMsg: "INVALID_SERVICE_EXTERNAL_IPS"

--- a/policies/opa/gatekeeper/constraints/8-svc-clusterip-ext-ips-allowed.yaml
+++ b/policies/opa/gatekeeper/constraints/8-svc-clusterip-ext-ips-allowed.yaml
@@ -1,0 +1,19 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sSvcClusterIpExternalIpsAllow
+metadata:
+  name: svc-clusterip-ext-ips-allow
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+    namespaces:
+      - "opa-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    allowedIps:
+      - 1.1.1.1
+      - 2.2.2.2
+      - 3.3.3.3
+      - 4.4.4.4
+    errMsg: "INVALID_SERVICE_EXTERNAL_IPS"

--- a/policies/opa/gatekeeper/test-resources/40-clusterip-service-ext-ips.yaml
+++ b/policies/opa/gatekeeper/test-resources/40-clusterip-service-ext-ips.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hijack-dns
+  namespace: opa-test
+spec:
+  selector:
+    app: hijack-dns-server
+  ports:
+    - name: dns
+      protocol: UDP
+      port: 53
+      targetPort: 9053
+  externalIPs:
+    - 1.1.1.1
+    - 2.2.2.2
+    - 3.3.3.3
+    - 4.4.4.4

--- a/policies/opa/gatekeeper/test-resources/41-clusterip-service-ext-ips.yaml
+++ b/policies/opa/gatekeeper/test-resources/41-clusterip-service-ext-ips.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hijack-dns
+  namespace: opa-test
+spec:
+  selector:
+    app: hijack-dns-server
+  ports:
+    - name: dns
+      protocol: UDP
+      port: 53
+      targetPort: 9053
+  externalIPs:
+    - 8.8.8.8
+    - 8.8.4.4


### PR DESCRIPTION
Added OPA classic and gatekeeper policies in response to k8s CVE https://github.com/kubernetes/kubernetes/issues/97076?utm_source=thenewstack&utm_medium=website&utm_campaign=platform

Policies are based on work seen here: https://github.com/open-policy-agent/gatekeeper-library/pull/39

