### PR TITLE
Update link to Gatekeeper library

### DIFF
--- a/content/security/docs/runtime.md
+++ b/content/security/docs/runtime.md
@@ -42,7 +42,7 @@ Before using seccomp, consider whether adding/removing Linux capabilities gives 
 Pod Security Policies offer a lot of different ways to improve your security posture without introducing undue complexity. Explore the options available in PSPs before venturing into building seccomp and Apparmor profiles. 
 
 !!! warning 
-    With the future propects of PSPs in doubt, you may want to look at implementing these controls using Pod security contexts or OPA/Gatekeeper. A collection of Gatekeeper constraints and constraint templates for implementing policies commonly found in PSPs can be pulled from the [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/tree/master/library/pod-security-policy) repository on GitHub.  
+    With the future propects of PSPs in doubt, you may want to look at implementing these controls using Pod security contexts or OPA/Gatekeeper. A collection of Gatekeeper constraints and constraint templates for implementing policies commonly found in PSPs can be pulled from the [Gatekeeper library](https://github.com/open-policy-agent/gatekeeper-library/tree/master/library/pod-security-policy) repository on GitHub.  
 
 ## Additional Resources
 + [7 things you should know before you start](https://itnext.io/seccomp-in-kubernetes-part-i-7-things-you-should-know-before-you-even-start-97502ad6b6d6)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The previous link returned a 404. Looking at the repo (https://github.com/open-policy-agent/gatekeeper/tree/master/library) it seems like the library moved out to a separate repo, which is now where the link points.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
