### PR TITLE
Added policy to block privilege escalation via setuid/setgid

### DIFF
--- a/policies/alternative-gatekeeper/README.md
+++ b/policies/alternative-gatekeeper/README.md
@@ -21,6 +21,7 @@ We started by recreating the example [Restricted legacy PSP template](https://ku
 | Descrption | Legacy PSP Field | Constraint and Constraint Template Files |
 | --- | --- | --- |
 | Block running privileged containers | `privileged` | psp_privileged.yaml |
+| Block  the ability for Pods to escalate privleges via `setuid` or `setgid` binaries etc. | `allowPrivilegeEscalation` | psp_privilege_escalation.yaml |
 | Block the ability for the Pods to request any Linux capabilities (e.g. NET_ADMIN | `defaultAddCapabilities`, `requiredDropCapabilities`, `allowedCapabilities` | psp_capabilities.yaml |
 | Block the ability for Pods to run as the root user | `runAsUser`, `runAsGroup`, `supplementalGroups`, `fsgroup` | psp_users.yaml |
 | Block the ability for Pods to use the host's namespace(s) | `hostPID`, `hostIPC` | psp_host_namespaces.yaml |
@@ -35,6 +36,12 @@ Privileged mode comes from Docker where it "enables access to all devices on the
 One of the main reasons why people generally want privileged mode is that it allows things running within a container on the host to call the local container runtime/socket and launch more containers. This is an anti-pattern with Kubernetes - which should be launching all the Pods/containers on all of its hosts. This means that if you need one Pod to launch other containers/Pods it should do so via the Kubernetes API.
 
 There is a more granular way to allow access to specific privileges/capabilities using the capabilities policy. We block both privleged mode as well as all the capabilities by default in that seperate policy as well.
+
+### Block privilege escalation
+
+Linux has a feature allowing particular executables to run as a different user and/or group than the one running it - setuid/setgid. This is primarily used to escalate the privileges of the current user.
+
+This requires the PodSpec to explicitly disable that feature.
 
 ### Block the ability for the Pods to request any Linux capabilities
 

--- a/policies/alternative-gatekeeper/policies/constraint-templates/psp_privilege_escalation.yaml
+++ b/policies/alternative-gatekeeper/policies/constraint-templates/psp_privilege_escalation.yaml
@@ -1,0 +1,38 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspallowprivilegeescalationcontainer
+  annotations:
+    description: Controls restricting escalation to root privileges.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAllowPrivilegeEscalationContainer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spspallowprivilegeescalationcontainer
+
+        violation[{"msg": msg, "details": {}}] {
+            c := input_containers[_]
+            input_allow_privilege_escalation(c)
+            msg := sprintf("Privilege escalation container is not allowed: %v", [c.name])
+        }
+
+        input_allow_privilege_escalation(c) {
+            not has_field(c, "securityContext")
+        }
+        input_allow_privilege_escalation(c) {
+            not c.securityContext.allowPrivilegeEscalation == false
+        }
+        input_containers[c] {
+            c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.initContainers[_]
+        }
+        # has_field returns whether an object has a field
+        has_field(object, field) = true {
+            object[field]
+        }

--- a/policies/alternative-gatekeeper/policies/constraints/psp_privilege_escalation.yaml
+++ b/policies/alternative-gatekeeper/policies/constraints/psp_privilege_escalation.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowPrivilegeEscalationContainer
+metadata:
+  name: psp-allow-privilege-escalation-container
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: ["kube-system"]

--- a/policies/alternative-gatekeeper/tests/allowed.yaml
+++ b/policies/alternative-gatekeeper/tests/allowed.yaml
@@ -29,6 +29,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/disallowed_tags.yaml
+++ b/policies/alternative-gatekeeper/tests/disallowed_tags.yaml
@@ -28,6 +28,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_capabilities.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_capabilities.yaml
@@ -27,6 +27,7 @@ spec:
         runAsGroup: 101
         capabilities:
           add: ["NET_ADMIN", "SYS_TIME"]
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_host_namespaces.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_host_namespaces.yaml
@@ -30,6 +30,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_host_network.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_host_network.yaml
@@ -30,6 +30,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_privilege_escalation.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_privilege_escalation.yaml
@@ -1,9 +1,10 @@
+# This is an example of a PodSpec that passes all our default checks
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx-containers-resource-ratios-disallowed
+  name: nginx-allowed
   labels:
-    app: nginx-containers-resource-ratios-disallowed
+    app: nginx-allowed
 spec:
   securityContext:
     supplementalGroups:
@@ -12,6 +13,13 @@ spec:
   containers:
     - name: nginx
       image: nginxinc/nginx-unprivileged:1.19
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 1
+          memory: 1Gi
       ports:
       - containerPort: 8080
         protocol: TCP
@@ -21,7 +29,7 @@ spec:
         capabilities:
           drop:
             - ALL
-        allowPrivilegeEscalation: false
+        allowPrivilegeEscalation: true
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_privileged.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_privileged.yaml
@@ -29,6 +29,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_users.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_users.yaml
@@ -22,6 +22,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/psp_volumes.yaml
+++ b/policies/alternative-gatekeeper/tests/psp_volumes.yaml
@@ -28,6 +28,7 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false
       readinessProbe:
           httpGet:
             scheme: HTTP

--- a/policies/alternative-gatekeeper/tests/required_probes.yaml
+++ b/policies/alternative-gatekeeper/tests/required_probes.yaml
@@ -28,3 +28,4 @@ spec:
         capabilities:
           drop:
             - ALL
+        allowPrivilegeEscalation: false


### PR DESCRIPTION
It was brought to my attention that the [restricted PSP](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml) blocked privilege escalation via setuid/setgid but I had missed that in the set of policies. Adding that.