### PR TITLE
Change safe-to-evict from a label to an annotation

### DIFF
--- a/content/cluster-autoscaling/cluster-autoscaling.md
+++ b/content/cluster-autoscaling/cluster-autoscaling.md
@@ -166,7 +166,7 @@ Some workloads are expensive to evict. Big data analysis, machine learning tasks
 
 Ensure that:
 
-* Expensive to evict pods have the label `cluster-autoscaler.kubernetes.io/safe-to-evict=false`
+* Expensive to evict pods have the annotation `cluster-autoscaler.kubernetes.io/safe-to-evict=false`
 
 ## Advanced Use Cases
 

--- a/content/security/docs/cluster-autoscaling.md
+++ b/content/security/docs/cluster-autoscaling.md
@@ -166,7 +166,7 @@ Some workloads are expensive to evict. Big data analysis, machine learning tasks
 
 Ensure that:
 
-* Expensive to evict pods have the label `cluster-autoscaler.kubernetes.io/safe-to-evict=false`
+* Expensive to evict pods have the annotation `cluster-autoscaler.kubernetes.io/safe-to-evict=false`
 
 ## Advanced Use Cases
 


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:* Currently `cluster-autoscaler.kubernetes.io/safe-to-evict=false` is noted to be a label. Looking at the FAQ for cluster-autoscaler, [this is actually meant to be used as an annotation instead](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node). This PR changes the word "label" to "annotation" to be in line with cluster-autoscaler's documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
