### PR TITLE
Fix Logs Insights query

### DIFF
--- a/content/security/docs/detective.md
+++ b/content/security/docs/detective.md
@@ -221,7 +221,7 @@ fields @timestamp, @message
 | sort @timestamp desc
 | limit 100
 | filter objectRef.resource="secrets" and verb in ["get", "watch", "list"] and responseStatus.code="401"
-| count() by bin(1m)
+| stats count() by bin(1m)
 ```
 List of failed anonymous requests:
 ```


### PR DESCRIPTION
Need `stats` to run `count()`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
