### PR TITLE
Clarify PreStop hook behavior

### DIFF
--- a/content/reliability/docs/application.md
+++ b/content/reliability/docs/application.md
@@ -214,7 +214,7 @@ $ kubectl exec python-app -it ps
 
 In this example, the shell script receives `SIGTERM`, the main process, which happens to be a Python application in this example, doesn’t get a `SIGTERM` signal. When the Pod is terminated, the Python application will be killed abruptly. This can be remediated by changing the [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint) of the container to launch the Python application. Alternatively, you can use a tool like [dumb-init](https://github.com/Yelp/dumb-init) to ensure that your application can handle signals.  
 
-You can also use [Container hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) to execute a script or an HTTP request at container start or stop. The `PreStop` hook action runs when the container receives a `SIGTERM` signal and is killed after `terminationGracePeriodSeconds`. 
+You can also use [Container hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) to execute a script or an HTTP request at container start or stop. The `PreStop` hook action runs before the container receives a `SIGTERM` signal and must complete before this signal is sent. The `terminationGracePeriodSeconds` value applies from when the `PreStop` hook action begins executing, not when the `SIGTERM` signal is sent.
 
 ## Recommendations
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The current content suggests that a `PreStop` hook executes at the same time the `SIGTERM` signal is sent to a container, which is not correct per the Kubernetes documentation. I'm working with a customer that is seeing undesirable Pod shutdown behavior and this is misleading.

https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks

This change updates the content to fix this misleading statement and better reflect the Kubernetes documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
