### PR TITLE
Add section to identify pods using a compromised image

### DIFF
--- a/content/security/docs/incidents.md
+++ b/content/security/docs/incidents.md
@@ -33,6 +33,17 @@ kubectl get pods -o json --namespace <namespace> | \
     "\(.metadata.name) \(.spec.nodeName)"'
 ```
 
+### Identify the offending Pods and worker nodes using container image
+In some cases, you may discover that a container image being used in pods on your cluster is malicious or compromised. A container image is malicious or compromised, if it was found to contain malware, is a known bad image or has a CVE that has been exploited. You should consider all the pods using the container image compromised. You can identify the pods using the image and nodes they are running on with the following command:
+```
+IMAGE=<Name of the malicious/compromised image>
+
+kubectl get pods -o json --all-namespaces | \
+    jq -r --arg image "$IMAGE" '.items[] | 
+    select(.spec.containers[] | .image == $image) | 
+    "\(.metadata.name) \(.metadata.namespace) \(.spec.nodeName)"'
+```
+
 ### Isolate the Pod by creating a Network Policy that denies all ingress and egress traffic to the pod
 A deny all traffic rule may help stop an attack that is already underway by severing all connections to the pod. The following Network Policy will apply to a pod with the label `app=web`. 
 ```yaml


### PR DESCRIPTION
*Description of changes:*
Added a section under the Incidents page titled "Identify the offending Pods and worker nodes using container image". It provides instructions to list pods using a specific image. In some cases, a pod compromise is due to a malicious or compromised image. It is important to identify all the pods using such an image and fix them. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
