### PR TITLE
add krew for aws auth

### DIFF
--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -123,7 +123,14 @@ go get github.com/keikoproj/aws-auth
 aws-auth help
 ```
 
-[Review the docs on GitHub](https://github.com/keikoproj/aws-auth/blob/master/README.md) for more information, including the go library.
+Alternatively, install `aws-auth` with the [krew plugin manager](https://krew.sigs.k8s.io) for kubectl.
+
+```
+kubectl krew install aws-auth
+kubectl aws-auth
+```
+
+[Review the aws-auth docs on GitHub](https://github.com/keikoproj/aws-auth/blob/master/README.md) for more information, including the go library.
 
 **[AWS IAM Authenticator CLI](https://github.com/kubernetes-sigs/aws-iam-authenticator/tree/master/cmd/aws-iam-authenticator)**
 


### PR DESCRIPTION
*Issue #, if available:*
n/a 

*Description of changes:*
add example of using krew to install aws-auth as a kubectl plugin. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
