### PR TITLE
fix(autoscaling): make links clickable in mkdocs

### DIFF
--- a/content/cluster-autoscaling/index.md
+++ b/content/cluster-autoscaling/index.md
@@ -250,10 +250,10 @@ This page contains a list of Cluster Autoscaler presentations and demos. If you'
 
 ## References
 
-* https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md
-* https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md
-* https://github.com/aws/amazon-ec2-instance-selector
-* https://github.com/aws/aws-node-termination-handler
+* [https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md)
+* [https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md)
+* [https://github.com/aws/amazon-ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector)
+* [https://github.com/aws/aws-node-termination-handler](https://github.com/aws/aws-node-termination-handler)
 
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make the links in the [cluster-autoscaling#references](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/#references) tab clickable
as they are currently displayed as plain text.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
