### PR TITLE
Improve pods.md to consider containers running on Windows

### DIFF
--- a/content/security/docs/pods.md
+++ b/content/security/docs/pods.md
@@ -467,6 +467,12 @@ securityContext:
 
 Policy-as-code and Pod Security Standards can be used to enforce this behavior.
 
+
+!!! Info 
+    
+    As per [Windows containers in Kubernetes](https://kubernetes.io/docs/concepts/windows/intro/) `securityContext.readOnlyRootFilesystem` cannot be set to
+    `true` for container running on Windows as write access is required for registry and system processes to run inside the container
+
 ## Tools and Resources
 
 + [open-policy-agent/gatekeeper-library: The OPA Gatekeeper policy library](https://github.com/open-policy-agent/gatekeeper-library) a library of OPA/Gatekeeper policies that you can use as a substitute for PSPs.

--- a/content/security/docs/pods.md
+++ b/content/security/docs/pods.md
@@ -471,7 +471,7 @@ Policy-as-code and Pod Security Standards can be used to enforce this behavior.
 !!! Info 
     
     As per [Windows containers in Kubernetes](https://kubernetes.io/docs/concepts/windows/intro/) `securityContext.readOnlyRootFilesystem` cannot be set to
-    `true` for container running on Windows as write access is required for registry and system processes to run inside the container
+    `true` for a container running on Windows as write access is required for registry and system processes to run inside the container.
 
 ## Tools and Resources
 


### PR DESCRIPTION
*Issue #, if available:*: N/A

*Description of changes:*

The change sets to clarify the `readOnlyRootFilesystem` pod security best practice as setting `readOnlyRootFilesystem: true` is not applicable for containers running on Windows as per https://kubernetes.io/docs/concepts/windows/intro/.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
