### PR TITLE
Update link to the subnet calculator

### DIFF
--- a/content/networking/index/index.md
+++ b/content/networking/index/index.md
@@ -45,7 +45,7 @@ EKS’s support for IPv6 is focused on solving the IP exhaustion problem caused 
 
 ## Subnet Calculator
 
-This project includes a [Subnet Calculator Excel Document]([https://github.com/aws/aws-eks-best-practices/tree/master/projects/subnet-calc). This calculator document simulates the IP address consumption of a specified workload under different ENI configuration options, such as `WARM_IP_TARGET` and `WARM_ENI_TARGET`. The document includes two sheets, a first for WarmE NI mode, and a second for Warm IP mode. Review the [VPC CNI guidance](../vpc-cni/index.md) for more information on these modes. 
+This project includes a [Subnet Calculator Excel Document]([https://github.com/aws/aws-eks-best-practices/blob/master/projects/subnet-calc/subnet-calc.xlsx). This calculator document simulates the IP address consumption of a specified workload under different ENI configuration options, such as `WARM_IP_TARGET` and `WARM_ENI_TARGET`. The document includes two sheets, a first for WarmE NI mode, and a second for Warm IP mode. Review the [VPC CNI guidance](../vpc-cni/index.md) for more information on these modes. 
 
 Inputs:
 - Subnet CIDR Size

--- a/content/networking/index/index.md
+++ b/content/networking/index/index.md
@@ -45,7 +45,7 @@ EKS’s support for IPv6 is focused on solving the IP exhaustion problem caused 
 
 ## Subnet Calculator
 
-This project includes a [Subnet Calculator Excel Document](../../../projects/subnet-calc/subnet-calc.xlsx). This calculator document simulates the IP address consumption of a specified workload under different ENI configuration options, such as `WARM_IP_TARGET` and `WARM_ENI_TARGET`. The document includes two sheets, a first for WarmE NI mode, and a second for Warm IP mode. Review the [VPC CNI guidance](../vpc-cni/index.md) for more information on these modes. 
+This project includes a [Subnet Calculator Excel Document]([https://github.com/aws/aws-eks-best-practices/tree/master/projects/subnet-calc). This calculator document simulates the IP address consumption of a specified workload under different ENI configuration options, such as `WARM_IP_TARGET` and `WARM_ENI_TARGET`. The document includes two sheets, a first for WarmE NI mode, and a second for Warm IP mode. Review the [VPC CNI guidance](../vpc-cni/index.md) for more information on these modes. 
 
 Inputs:
 - Subnet CIDR Size


### PR DESCRIPTION
Previous link didn't work for GithubPages, can be tested from https://aws.github.io/aws-eks-best-practices/networking/index/#subnet-calculator Changed to absolute path

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
