### PR TITLE
Fix Calico GlobalNetworkPolicy apiVersion 

### DIFF
--- a/content/security/docs/network.md
+++ b/content/security/docs/network.md
@@ -46,7 +46,7 @@ spec:
 
 _Calico global network policy_
 ```yaml
-apiVersion: crd.projectcalico.org/v1
+apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
 metadata:
   name: default-deny
@@ -92,7 +92,7 @@ spec:
 _Calico global policy equivalent_
 
 ```yaml
-apiVersion: crd.projectcalico.org/v1
+apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
 metadata:
   name: allow-dns-egress
@@ -102,7 +102,7 @@ spec:
   - Egress
   egress:
   - action: Allow
-    protocol: UDP  
+    protocol: UDP
     destination:
       namespaceSelector: name == "kube-system"
       ports:
@@ -147,7 +147,7 @@ roleRef:
   name: readonly-sa-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: crd.projectcalico.org/v1
+apiVersion: projectcalico.org/v3
 kind: NetworkPolicy
 metadata:
   name: netpol-sa-demo
@@ -238,7 +238,7 @@ If you need to control communication between services that run within the cluste
 !!! warning
     If you reference a security group that does not exist prior to the creation of the pods, the pods will not get scheduled.
 
-You can control which pods are assigned to a security group by creating a `SecurityGroupPolicy` object and specifying a `PodSelector` or a `ServiceAccountSelector`. Setting the selectors to `{}` will assign the SGs referenced in the `SecurityGroupPolicy` to all pods in a namespace or all Service Accounts in a namespace. Be sure you've familiarized yourself with all the [considerations](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-considerations) before implementing security groups for pods.  
+You can control which pods are assigned to a security group by creating a `SecurityGroupPolicy` object and specifying a `PodSelector` or a `ServiceAccountSelector`. Setting the selectors to `{}` will assign the SGs referenced in the `SecurityGroupPolicy` to all pods in a namespace or all Service Accounts in a namespace. Be sure you've familiarized yourself with all the [considerations](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-considerations) before implementing security groups for pods.
 
 !!! important
     If you use SGs for pods you **must** create SGs that allow port 53 outbound to the cluster security group.  Similarly, you **must** update the cluster security group to accept port 53 inbound traffic from the pod security group.
@@ -312,7 +312,7 @@ Now that you have a Private CA and an EKS cluster with cert-manager and the plug
             ],
             "Effect": "Allow",
             "Resource": "<CA_ARN>"
-        }       
+        }
     ]
 }
 ```


### PR DESCRIPTION
*Description of changes:*
As explained in https://github.com/projectcalico/calico/issues/6412, `crd.projectcalico.org/v1` is not currently supported for end-users.  We should use `projectcalico.org/v3` instead.

Not following this recommendation will result in `Error from server (NotFound)` error message and Calico will not behave as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
