### PR TITLE
autoscaling: add ec2:DescribeInstanceTypes to IAM role policy

### DIFF
--- a/content/cluster-autoscaling/index.md
+++ b/content/cluster-autoscaling/index.md
@@ -66,7 +66,8 @@ This will prevents a Cluster Autoscaler running in one cluster from modifying no
                 "autoscaling:DescribeAutoScalingGroups",
                 "ec2:DescribeLaunchTemplateVersions",
                 "autoscaling:DescribeTags",
-                "autoscaling:DescribeLaunchConfigurations"
+                "autoscaling:DescribeLaunchConfigurations",
+                "ec2:DescribeInstanceTypes"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
*Issue #, if available:*

The `ec2:DescribeInstanceTypes` should be added to IAM role policy of autoscaling, otherwise, the `cluster-autoscaler` could stuck at Crash Backoff state for CA v1.23.0 and v1.24.0.

*Description of changes:*

Add  `ec2:DescribeInstanceTypes`  to IAM role policy of autoscaling per doc https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
