### PR TITLE
Inconsistent recommendation for `--balance-similar-node-groups`

### DIFF
--- a/content/cluster-autoscaling/index.md
+++ b/content/cluster-autoscaling/index.md
@@ -224,7 +224,7 @@ Machine learning distributed training jobs benefit significantly from the minimi
 
 Ensure that:
 
-* Node group balancing is enabled by setting `balance-similar-node-groups=false`
+* Node group balancing is enabled by setting `balance-similar-node-groups=true`
 * [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) and/or [Pod Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) is used when clusters include both Regional and Zonal Node Groups.
     * Use [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to force or encourage regional pods to avoid zonal Node Groups, and vice versa.
     * If zonal pods schedule onto regional node groups, this will result in imbalanced capacity for your regional pods.


### PR DESCRIPTION
Sections on EBS Volumes and Co-Scheduling both recommend "Node group balancing is enabled" but one says to set `balance-similar-node-groups` to `true`, and the other says to set it to `false`. 

*Issue #, if available:* n/a

*Description of changes:*

In both sections, enabling this feature is achieved by setting it to `true`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
