### PR TITLE
[docfix] Remove reference to etcd metrics not exposed

### DIFF
--- a/content/reliability/docs/controlplane.md
+++ b/content/reliability/docs/controlplane.md
@@ -200,7 +200,7 @@ AWS sets service limits (an upper limit on the number of each resource your team
 - Besides the limits from orchestration engines, there are limits in other AWS services, such as Elastic Load Balancing (ELB) and Amazon VPC, that may affect your application performance.
 - More about EC2 limits here: [EC2 service limits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html).
 - Each EC2 instance limits the number of packets that can be sent to the [Amazon-provided DNS server](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-limits) to a maximum of 1024 packets per second per network interface.
-- In EKS environment, etcd storage limit is **8GB** as per [upstream guidance](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit). Please monitor metric `etcd_db_total_size_in_bytes` to track etcd db size. You can refer to [alert rules](https://github.com/etcd-io/etcd/blob/main/contrib/mixin/mixin.libsonnet#L213-L240) `etcdBackendQuotaLowSpace` and `etcdExcessiveDatabaseGrowth` to setup this monitoring.
+- In EKS environment, etcd storage limit is **8GB** as per [upstream guidance](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit).
 
 ## Additional Resources:
 


### PR DESCRIPTION
*Description of changes:*

The following referenced metrics are not exposed the Amazon EKS API servers and are confusing to reference to end-users:
- `etcd_mvcc_db_total_size_in_bytes`
- `etcd_server_quota_backend_bytes`

I actually do not like my approach here of just wholesale removing this line. I thing that we should do one/multiple of the following:

- Open an issue against Amazon EKS to expose these metrics to end-users.
- Provide a modified version of the referenced alerts to match what we _do_ currently have in Amazon EKS.
- Give direction to see the `ectd` section further up in the documentation which uses `max(etcd_db_total_size_in_bytes) / (8 * 1024 * 1024 * 1024)`.

Feel free to add to/modify PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
