### PR TITLE
fixes-issue-294-deprecated-registries

### DIFF
--- a/policies/k8s-registry-deprecation/README.md
+++ b/policies/k8s-registry-deprecation/README.md
@@ -1,0 +1,18 @@
+This folder contains example Gatekeeper and Kyverno policies to detect the use of container images that use the now deprecated, soon to be frozen, `k8s.gcr.io` container image registry.
+
+Policies should work for the following resources:
+- Pod
+- Deployment
+- DaemonSet
+- Job
+- StatefulSet
+- ReplicaSet
+
+And the following containers:
+- containers
+- initContainers
+- ephemeralContainers
+
+The policies are set to enforce mode, by can be set to warn/audit modes.
+
+

--- a/policies/k8s-registry-deprecation/gatekeeper/deprecated-registry-c.yaml
+++ b/policies/k8s-registry-deprecation/gatekeeper/deprecated-registry-c.yaml
@@ -1,0 +1,18 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDeprecatedRegistry
+metadata:
+  name: denied-deprecated-registry
+  labels:
+    policy.kubernetes.amazon-eks.com/gatekeeper: constraint
+spec:
+  # enforcementAction: warn
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod","Deployment","DaemonSet","Job","CronJob","StatefulSet","ReplicaSet"]
+    # namespaces:
+    #   - "policy-test"
+  parameters:
+    allowedOps: ["CREATE","UPDATE"]
+    deniedRegistries: ["k8s.gcr.io"]
+    errMsg: "INVALID_REGISTRY"

--- a/policies/k8s-registry-deprecation/gatekeeper/deprecated-registry-ct.yaml
+++ b/policies/k8s-registry-deprecation/gatekeeper/deprecated-registry-ct.yaml
@@ -1,0 +1,131 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdeprecatedregistry
+  labels:
+    policy.kubernetes.amazon-eks.com/gatekeeper: template 
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDeprecatedRegistry
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedOps:
+              type: array
+              items:
+                type: string
+            deniedRegistries:
+              type: array
+              items:
+                type: string
+            errMsg:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sdeprecatedregistry
+
+        import future.keywords.in
+
+        # Pod containers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.containers[_].image
+          name := input.review.object.spec.containers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # Pod initContainers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.initContainers[_].image
+          name := input.review.object.spec.initContainers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # Pod ephemeralContainers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.ephemeralContainers[_].image
+          name := input.review.object.spec.ephemeralContainers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # CronJob containers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.jobTemplate.spec.containers[_].image
+          name := input.review.object.spec.jobTemplate.spec.containers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # CronJob initContainers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.jobTemplate.spec.initContainers[_].image
+          name := input.review.object.spec.jobTemplate.spec.initContainers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # CronJob ephemeralContainers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.jobTemplate.spec.ephemeralContainers[_].image
+          name := input.review.object.spec.jobTemplate.spec.ephemeralContainers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # Workload containers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.template.spec.containers[_].image
+          name := input.review.object.spec.template.spec.containers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # Workload initContainers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.template.spec.initContainers[_].image
+          name := input.review.object.spec.template.spec.initContainers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        # Workload ephemeralContainers
+        violation[{"msg": msg, "details": {}}] {
+          input.review.operation in input.parameters.allowedOps
+          image := input.review.object.spec.template.spec.ephemeralContainers[_].image
+          name := input.review.object.spec.template.spec.ephemeralContainers[_].name
+          badRegs := input.parameters.deniedRegistries
+          reg_matches_any(image, badRegs) = true
+          msg = sprintf("%v: Container=%v, Image=%v. The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used. Resource ID (ns/name/kind): %v/%v/%v",[input.parameters.errMsg, name, image, input.review.object.metadata.namespace, input.review.object.metadata.name, input.review.kind.kind])
+        }
+
+        reg_matches_any(str, patterns) {
+          reg_matches(str, patterns[_])
+        }
+
+        reg_matches(str, pattern) {
+          contains(str, pattern)
+        }
+

--- a/policies/k8s-registry-deprecation/kyverno/deprecated-registry.yaml
+++ b/policies/k8s-registry-deprecation/kyverno/deprecated-registry.yaml
@@ -1,0 +1,37 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deprecated-registry
+  annotations:
+    policies.kyverno.io/title: Restrict Image Registries
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Legacy k8s.gcr.io container image registry will be frozen in early April 2023
+      k8s.gcr.io image registry will be frozen from the 3rd of April 2023.  
+      Images for Kubernetes 1.27 will not be available in the k8s.gcr.io image registry.
+      Please read our announcement for more details.
+      https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/     
+spec:
+  validationFailureAction: Enforce
+  # validationFailureAction: Audit
+  background: true
+  rules:
+  - name: deprecated-registry
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+        message: "The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used."
+        foreach:
+          - list: "request.object.spec.[initContainers, ephemeralContainers, containers][]"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ element.image }}"
+                    operator: Equals
+                    value: "k8s.gcr.io/*"


### PR DESCRIPTION
*Issue #294 , if available:*

*Description of changes:*
Added Gatekeeper and Kyverno policies for detecting deprecated `k8s.gcr.io` registries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
