### PR TITLE
Fix incorrect hostname of new registry

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  The Kubernetes project is moving its container image registry for community images from k8s.gcr.io to a new community owned image registry registry.k8.io. Please update your manifests accordingly. For additional information, please refer to this <a href="https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/" style="color:#40FF33;">announcement</a> on the Kubernetes blog.
+  The Kubernetes project is moving its container image registry for community images from k8s.gcr.io to a new community owned image registry registry.k8s.io. Please update your manifests accordingly. For additional information, please refer to this <a href="https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/" style="color:#40FF33;">announcement</a> on the Kubernetes blog.
 {% endblock %}


### PR DESCRIPTION
*Issue #, if available:*
registry.k8.io is not a correct hostname, it should be registry.k8s.io

*Description of changes:*
change registry hostname mentioned in overrides

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
