### PR TITLE
Fix cluster-autoscaling least privilege docs

### DIFF
--- a/content/cluster-autoscaling/index.md
+++ b/content/cluster-autoscaling/index.md
@@ -54,7 +54,7 @@ This will prevents a Cluster Autoscaler running in one cluster from modifying no
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
-                    "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
+                    "aws:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
                     "aws:ResourceTag/k8s.io/cluster-autoscaler/<my-cluster>": "owned"
                 }
             }


### PR DESCRIPTION
Fixes a type in the IAM policy example. Namely 'autoscaling:ResourceTag' -> 'aws:ResourceTag'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
