### PR TITLE
Remove IMDSv1 guidance that could result in privilege escalation

### DIFF
--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -301,47 +301,7 @@ resource "aws_launch_template" "foo" {
 
 You can also block a pod's access to EC2 metadata by manipulating iptables on the node. For further information about this method, see [Limiting access to the instance metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-limiting-access).
 
-If you have an application that is using an older version of the AWS SDK that doesn't support IRSA, and you want the pod to inherit the role assigned to the instance, consider using Kubernetes network policies to **selectively** allow access EC2 metadata.
-
-Start with a policy that blocks access to the metadata service from all Pods:
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: deny-metadata-access
-  namespace: example
-spec:
-  podSelector: {}
-  policyTypes:
-  - Egress
-  egress:
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-        except:
-        - 169.254.169.254/32
-```
-
-Then allow access from select pods by adding following policy, modifying the `PodSelector` as appropriate.
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-metadata-access
-  namespace: example
-spec:
-  podSelector:
-    matchLabels:
-      app: myapp  
-  policyTypes:
-  - Egress
-  egress:
-  - to:
-    - ipBlock:
-        cidr: 169.254.169.254/32
-```
+If you have an application that is using an older version of the AWS SDK that doesn't support IRSA, you should update the SDK version.
 
 ### Scope the IAM Role trust policy for IRSA to the service account name
 The trust policy can be scoped to a Namespace or a specific service account within a Namespace. When using IRSA it's best to make the role trust policy as explicit as possible by including the service account name. This will effectively prevent other Pods within the same Namespace from assuming the role. The CLI `eksctl` will do this automatically when you use it to create service accounts/IAM roles. See [https://eksctl.io/usage/iamserviceaccounts/](https://eksctl.io/usage/iamserviceaccounts/) for further information. 


### PR DESCRIPTION
[Based on my understanding of how privilege escalation works in EKS](https://blog.calif.io/p/privilege-escalation-in-eks), I removed some guidance around using network policies to restrict access to IMDSv1 as it could still result in privilege escalation. If you allow access to IMDSv1 on a pod, that pod could get an access token and potentially escalate their privileges.

I'm not sure if this change/guidance is necessarily how this should be updated, but wanted to start a conversation and go from there.

*Issue #, if available:* N/A

*Description of changes:*
Remove IMDSv1 guidance that could result in privilege escalation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
