### PR TITLE
Update CoreDNS metric name

### DIFF
--- a/content/reliability/docs/dataplane.md
+++ b/content/reliability/docs/dataplane.md
@@ -215,7 +215,7 @@ CoreDNS fulfills name resolution and service discovery functions in Kubernetes. 
 
 ## Recommendations
 ### Monitor CoreDNS metrics
-CoreDNS has built in support for [Prometheus](https://github.com/coredns/coredns/tree/master/plugin/metrics). You should especially consider monitoring CoreDNS latency (`coredns_dns_request_duration_seconds_sum`), errors (`coredns_dns_response_rcode_count_total`, NXDOMAIN, SERVFAIL, FormErr) and CoreDNS Pod’s memory consumption.
+CoreDNS has built in support for [Prometheus](https://github.com/coredns/coredns/tree/master/plugin/metrics). You should especially consider monitoring CoreDNS latency (`coredns_dns_request_duration_seconds_sum`), errors (`coredns_dns_responses_total`, NXDOMAIN, SERVFAIL, FormErr) and CoreDNS Pod’s memory consumption.
 
 For troubleshooting purposes, you can use kubectl to view CoreDNS logs:
 

--- a/content/reliability/docs/dataplane.md
+++ b/content/reliability/docs/dataplane.md
@@ -215,7 +215,7 @@ CoreDNS fulfills name resolution and service discovery functions in Kubernetes. 
 
 ## Recommendations
 ### Monitor CoreDNS metrics
-CoreDNS has built in support for [Prometheus](https://github.com/coredns/coredns/tree/master/plugin/metrics). You should especially consider monitoring CoreDNS latency (`coredns_dns_request_duration_seconds_sum`), errors (`coredns_dns_responses_total`, NXDOMAIN, SERVFAIL, FormErr) and CoreDNS Pod’s memory consumption.
+CoreDNS has built in support for [Prometheus](https://github.com/coredns/coredns/tree/master/plugin/metrics). You should especially consider monitoring CoreDNS latency (`coredns_dns_request_duration_seconds_sum`, before [1.7.0](https://github.com/coredns/coredns/blob/master/notes/coredns-1.7.0.md) version the metric was called `core_dns_response_rcode_count_total`), errors (`coredns_dns_responses_total`, NXDOMAIN, SERVFAIL, FormErr) and CoreDNS Pod’s memory consumption.
 
 For troubleshooting purposes, you can use kubectl to view CoreDNS logs:
 


### PR DESCRIPTION
- `coredns_dns_response_rcode_count_total` renamed in CoreDNS 1.7.0
- https://coredns.io/2020/06/15/coredns-1.7.0-release

*Issue #, if available:*

*Description of changes:*

Correct the CoreDNS metrics name since `coredns_dns_response_rcode_count_total` was renamed in CoreDNS 1.7.0
