### PR TITLE
current EKS version upgrade documentations added

### DIFF
--- a/content/upgrades/index.md
+++ b/content/upgrades/index.md
@@ -59,6 +59,8 @@ The EKS Kubernetes [version documentation](https://docs.aws.amazon.com/eks/lates
 
 For specific EKS version upgrade guidance, review the documentation for notable changes and considerations for each version.
 
+* [EKS 1.27](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.27)
+* [EKS 1.26](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.26)
 * [EKS 1.25](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.25)
 * [EKS 1.24](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.24)
 * [EKS 1.23](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23)


### PR DESCRIPTION
Versions 1.26 and 1.27 of EKS are available. 
Updated the links that point to the according official documentations.