### PR TITLE
Removed QoS from Pod Priority and preemption

### DIFF
--- a/content/security/docs/multitenancy.md
+++ b/content/security/docs/multitenancy.md
@@ -85,7 +85,7 @@ You can also use quotas to apportion the cluster's resources to align with a ten
 
 ### Pod priority and preemption
 
-Pod priority and preemption can be useful when you want to provide different qualities of services (QoS) for different customers.  For example, with pod priority you can configure pods from customer A to run at a higher priority than customer B. When there's insufficient capacity available, the Kubelet will evict the lower-priority pods from customer B to accommodate the higher-priority pods from customer A.  This can be especially handy in a SaaS environment where customers willing to pay a premium receive a higher quality of service.
+Pod priority and preemption can be useful when you want to provide more importance to a Pod relative to other Pods.  For example, with pod priority you can configure pods from customer A to run at a higher priority than customer B. When there's insufficient capacity available, the scheduler will evict the lower-priority pods from customer B to accommodate the higher-priority pods from customer A.  This can be especially handy in a SaaS environment where customers willing to pay a premium receive a higher priority.
 
 ## Mitigating controls
 

--- a/content/security/docs/multitenancy.md
+++ b/content/security/docs/multitenancy.md
@@ -88,7 +88,7 @@ You can also use quotas to apportion the cluster's resources to align with a ten
 Pod priority and preemption can be useful when you want to provide more importance to a Pod relative to other Pods.  For example, with pod priority you can configure pods from customer A to run at a higher priority than customer B. When there's insufficient capacity available, the scheduler will evict the lower-priority pods from customer B to accommodate the higher-priority pods from customer A.  This can be especially handy in a SaaS environment where customers willing to pay a premium receive a higher priority.
 
 !!! attention 
-    Pods priority can have an undesired effect on other Pods with lower priority.For example, although the victim pods are terminated gracefully but the PodDisruptionBudget is not guaranteed, which could break a application with lower priority that relies on a quorum of Pods, see [Limitations of preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#limitations-of-preemption).
+    Pods priority can have an undesired effect on other Pods with lower priority. For example, although the victim pods are terminated gracefully but the PodDisruptionBudget is not guaranteed, which could break a application with lower priority that relies on a quorum of Pods, see [Limitations of preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#limitations-of-preemption).
 
 ## Mitigating controls
 

--- a/content/security/docs/multitenancy.md
+++ b/content/security/docs/multitenancy.md
@@ -87,6 +87,9 @@ You can also use quotas to apportion the cluster's resources to align with a ten
 
 Pod priority and preemption can be useful when you want to provide more importance to a Pod relative to other Pods.  For example, with pod priority you can configure pods from customer A to run at a higher priority than customer B. When there's insufficient capacity available, the scheduler will evict the lower-priority pods from customer B to accommodate the higher-priority pods from customer A.  This can be especially handy in a SaaS environment where customers willing to pay a premium receive a higher priority.
 
+!!! attention 
+    Pods priority can have an undesired effect on other Pods with lower priority.For example, although the victim pods are terminated gracefully but the PodDisruptionBudget is not guaranteed, which could break a application with lower priority that relies on a quorum of Pods, see [Limitations of preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#limitations-of-preemption).
+
 ## Mitigating controls
 
 Your chief concern as an administrator of a multi-tenant environment is preventing an attacker from gaining access to the underlying host. The following controls should be considered to mitigate this risk: 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the wording of pod priority
1. Pod priority does not define QoS. QoS is defined by setting resource limits to pod - https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/
2. Pod Priority is used by the scheduler and not the Kubelet. Kubelet uses QoS for evicting pods when nodes run out of resources. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
3. Added a attention scenario where pod priority can impact negatively. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#limitations-of-preemption

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
