### PR TITLE
enable prefix mode for Windows

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ nav:
       - VPC and Subnet Considerations: "networking/subnets/index.md"
       - Amazon VPC CNI: "networking/vpc-cni/index.md"
       - Prefix Mode for Linux: "networking/prefix-mode/index_linux.md"
-      #- Prefix Mode for Windows: "networking/prefix-mode/index_windows.md"
+      - Prefix Mode for Windows: "networking/prefix-mode/index_windows.md"
       - Running IPv6 Clusters: "networking/ipv6/index.md"
       - Security Groups per Pod: "networking/sgpp/index.md"
       - Custom Networking: "networking/custom-networking/index.md"


### PR DESCRIPTION
Since the feature has been released, we can enable prefix mode for Windows page.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
