### PR TITLE
Update the support statement in the shared VPC section

### DIFF
--- a/content/networking/subnets/index.md
+++ b/content/networking/subnets/index.md
@@ -93,9 +93,7 @@ VPC connectivity is best achieved when using non-overlapping IP ranges for each 
 
 ### Sharing VPC across multiple accounts
 
-Customers can share subnets with other AWS accounts inside the same AWS Organization via [VPC sharing](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html). Sharing a VPC is advised for larger organizations aiming to achieve separation of roles. VPC sharing is beneficial for a central networking team administering a centrally managed VPC, routing, and IP address allocation, while letting application owners to retain ownership over their own resources, accounts, and security groups. Consider VPC sharing to save costs by reusing NAT gateways, VPC interface endpoints, and intra-Availability Zone traffic. You may increase subnet density and prevent subnet fragmentation with VPC sharing.
-
-You can use VPC sharing with EKS clusters. We propose creating distinct subnets and EKS clusters for each application team. Please refer to this [blog](https://aws.amazon.com/blogs/networking-and-content-delivery/vpc-sharing-a-new-approach-to-multiple-accounts-and-vpc-management/) post to learn more about VPC sharing.
+Currently EKS does not support creating or managing EKS resources in shared VPCs or shared subnets.
 
 ### Security Groups 
 


### PR DESCRIPTION
The shared VPC/subnet capability has never been formally tested by EKS engineering and it is not included in our regular release testing. In a recent ad-hoc test, we found sub-cluster level resource creation and management doesn't work; creating an entire EKS cluster in a shared VPC/subnet might work but no guarantee it won't break in the future without formal engineering support (e.g. include it in regular testing). We should be unambiguous that this isn't supported by EKS right now and update the doc again after we formally add the feature support.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
