### PR TITLE
Update reference to old --cluster flag

### DIFF
--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -9,7 +9,7 @@ The webhook authentication strategy calls a webhook that verifies bearer tokens.
 To manually generate a authentication token, type the following command in a terminal window: 
 
 ```bash
-aws eks get-token --cluster <cluster_name>
+aws eks get-token --cluster-name <cluster_name>
 ```
 
 You can also get a token programmatically. Below is an example written in Go: 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I got the following error when running the command as documented with `aws-cli/2.13.7`:

```
aws: error: ambiguous option: --cluster could match --cluster-name, --cluster-id
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
