### PR TITLE
Handle repo-specific exceptions when checking links

### DIFF
--- a/.github/actions/linkbot/linkbot/__main__.py
+++ b/.github/actions/linkbot/linkbot/__main__.py
@@ -1,5 +1,7 @@
 import pathlib
 
+from github.GithubException import GithubException, RateLimitExceededException
+
 from .checks import check_failure_for_stats
 from .config import LinkBotConfig
 from .links import github_links_in_files, github_links_in_strs
@@ -14,17 +16,26 @@ all_links = github_links_in_files(repo_root, conf.glob)
 bot_messages = gh.get_open_issue_messages(conf.repo_url, conf.gh_user)
 existing_links = github_links_in_strs(bot_messages)
 for link in all_links:
-    if link in existing_links:
-        print(f'Issue already exists for {link}, skipping.')
+    try:
+        if link in existing_links:
+            print(f'Issue already exists for {link}, skipping.')
+            continue
+        print(f'Fetching data for {link}')
+        stats = gh.get_repo_stats(link)
+        failure = check_failure_for_stats(stats, conf.max_days_old)
+        if not failure:
+            continue
+        print(f'Check failed for {link}: {debug_message(stats, failure)}')
+        if conf.dry_run:
+            print('Dry run, not creating issue.')
+            continue
+        issue = gh.create_issue(conf.repo_url, render_title(stats, failure), render_body(stats, failure))
+        print(f'Created issue {issue.number} for {link}')
+    except RateLimitExceededException as e:
+        # Do not continue in the face of rate limit exceptions
+        raise e
+    except GithubException as e:
+        # Sometimes repo-specific exceptions occur, such as org-level IP allowlists blocking API calls
+        # Proceed to next issues in such cases
+        print('WARNING: Encountered unexpected GitHub exception:', e)
         continue
-    print(f'Fetching data for {link}')
-    stats = gh.get_repo_stats(link)
-    failure = check_failure_for_stats(stats, conf.max_days_old)
-    if not failure:
-        continue
-    print(f'Check failed for {link}: {debug_message(stats, failure)}')
-    if conf.dry_run:
-        print('Dry run, not creating issue.')
-        continue
-    issue = gh.create_issue(conf.repo_url, render_title(stats, failure), render_body(stats, failure))
-    print(f'Created issue {issue.number} for {link}')

--- a/.github/actions/linkbot/linkbot/config.py
+++ b/.github/actions/linkbot/linkbot/config.py
@@ -17,7 +17,8 @@ class LinkBotConfig:
             self.dry_run = os.environ.get('LINKBOT_DRY_RUN', 'false').lower() == 'true'
             # GH login info used for creating issues
             self.gh_user = os.environ['LINKBOT_GH_USER']
-            self.gh_token = os.environ['LINKBOT_GH_TOKEN']
+            # Allow unauthenticated use, handy for e.g. testing rate limits
+            self.gh_token = os.environ.get('LINKBOT_GH_TOKEN')
         except KeyError as e:
             print('Error: %s is a required config value' % e)
             exit(1)

--- a/.github/actions/linkbot/linkbot/github.py
+++ b/.github/actions/linkbot/linkbot/github.py
@@ -8,8 +8,12 @@ from .checks import RepoStats
 
 class Client:
 
-    def __init__(self, token):
-        self._pygh = Github(auth=Auth.Token(token))
+    def __init__(self, token=None):
+        if token:
+            self._pygh = Github(auth=Auth.Token(token))
+        else:
+            print('WARNING: Making unauthenticated calls to GitHub API...')
+            self._pygh = Github()
 
     @staticmethod
     def repo_full_name_from_url(url):


### PR DESCRIPTION
Follow-up to the recent link-checking addition. The process will now proceed in the face of repo-specific failures.
