### PR TITLE
Seccomp updates

### DIFF
--- a/.github/actions/linkbot/linkbot/report.py
+++ b/.github/actions/linkbot/linkbot/report.py
@@ -21,7 +21,7 @@ def render_body(stats, failure):
         )
     elif failure == CheckFailures.TOO_LONG_SINCE_DEFAULT_COMMIT:
         message = (
-            f'The project [{stats.full_name}]({stats.url}) does not have any commits to its defaul branch since '
+            f'The project [{stats.full_name}]({stats.url}) does not have any commits to its default branch since '
             f'{stats.latest_default_commit.date().isoformat()}. Please check if the project is still maintained.'
         )
     else:

--- a/content/security/docs/hosts.md
+++ b/content/security/docs/hosts.md
@@ -100,7 +100,7 @@ Amazon Inspector can provide common vulnerabilities and exposures (CVE) data for
 ### Run SELinux
 
 !!! info
-    Available on Red Hat Enterprise Linux (RHEL), CentOS, and CoreOS
+    Available on Red Hat Enterprise Linux (RHEL), CentOS, Bottlerocket, and Amazon Linux 2023
 
 SELinux provides an additional layer of security to keep containers isolated from each other and from the host. SELinux allows administrators to enforce mandatory access controls (MAC) for every user, application, process, and file.  Think of it as a backstop that restricts the operations that can be performed against to specific resources based on a set of labels.  On EKS, SELinux can be used to prevent containers from accessing each other's resources.
 

--- a/content/security/docs/network.md
+++ b/content/security/docs/network.md
@@ -268,7 +268,7 @@ Please note that migration tool is currently not supported by AWS VPC CNI Networ
 + [Calico Enterprise](https://www.tigera.io/tigera-products/calico-enterprise/)
 + [Cilium](https://cilium.readthedocs.io/en/stable/intro/)
 + [NetworkPolicy Editor](https://cilium.io/blog/2021/02/10/network-policy-editor) an interactive policy editor from Cilium
-+ [Kinvolk's Network Policy Advisor](https://kinvolk.io/blog/2020/03/writing-kubernetes-network-policies-with-inspektor-gadgets-network-policy-advisor/) Suggests network policies based on an analysis of network traffic
++ [Inspektor Gadget advise network-policy gadget](https://www.inspektor-gadget.io/docs/latest/gadgets/advise/network-policy/) Suggests network policies based on an analysis of network traffic
 
 
 ## Encryption in transit

--- a/content/security/docs/runtime.md
+++ b/content/security/docs/runtime.md
@@ -25,7 +25,7 @@ securityContext:
     type: RuntimeDefault
 ```
 
-As of 1.22 (in alpha, stable as of 1.27), the above `RuntimeDefault` can be used for all Pods on a Node using a [single kubelet flag](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads), `--seccomp-default`. The annotation is no longer needed, and the `securityContext` profile is only needed for other profiles.
+As of 1.22 (in alpha, stable as of 1.27), the above `RuntimeDefault` can be used for all Pods on a Node using a [single kubelet flag](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads), `--seccomp-default`. Then the profile specified in `securityContext` is only needed for other profiles.
 
 It's also possible to create your own profiles for things that require additional privileges. This can be very tedious to do manually, but there are tools like [Inspektor Gadget](https://github.com/inspektor-gadget/inspektor-gadget) (also recommended in the [network security section](../network/) for generating network policies) and [Security Profiles Operator](https://github.com/inspektor-gadget/inspektor-gadget) that support using tools like eBPF or logs to record baseline privilege requirements as seccomp profiles. Security Profiles Operator further allows automating the deployment of recorded profiles to nodes for use by Pods and containers.
 


### PR DESCRIPTION
*Issue #, if available:* 361, 362

*Description of changes:* The impetus for this PR was to remove the recommendations for unmaintained repos syscall2seccomp and Bane. This updates them with recommendations for Security Profiles Operator and Inspektor Gadget (including discussion of their broader scope, such as automatically deploying profiles to nodes). In the process, I updated a few things where it seemed to make sense related to security contexts, seccomp, SELinux, and AppArmor.

Here is a more thorough list of specific changes:
* Remove references to unmaintained Bane and syscall2seccomp projects, and replace with Security Profiles Operator and Inspektor Gadget
* Reorganize document in line with the securityContext API subresource (particularly now that e.g. seccomp profiles can always be specified there in current versions)
* Add notes relevant to non-Docker runtimes (now that the latest EKS versions use containerd by default)
* Remove some warnings about old (1.22 and older) versions no longer supported by EKS
* Rename existing seccomp-operator reference to its new name [security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator)
* Remove reference to CoreOS, add references to Bottlerocket and Amazon Linux 2023 (in the context of SELinux support)
* Link to related doc sections (network security for Inspektor Gadget and infra security for SELinux)
* Update reference to “Inspektor Gadget” instead of “Kinvolk's Network Policy Advisor” now that it is a CNCF project
* Add discussion of SELinux in addition to AppArmor
* Add a basic description and examples of Linux capabilities
* Unrelated but trivial typo fix in the “linkbot” scans (defaul→default)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
