### PR TITLE
add recommendation for CoreDNS readiness probe + add recommendation when deploying CoreDNS pods on nodes managed by Karpenter

### DIFF
--- a/content/karpenter/index.md
+++ b/content/karpenter/index.md
@@ -302,6 +302,16 @@ Karpenter is able to launch nodes that best fit your workloads when its informat
 
 See [Configure and Size Resource Requests/Limits for all Workloads](https://aws.github.io/aws-eks-best-practices/reliability/docs/dataplane/#configure-and-size-resource-requestslimits-for-all-workloads)
 
+### CoreDNS recommendations
+ 
+When deploying CoreDNS pods on nodes managed by Karpenter, given Karpenter's dynamic nature in rapidly terminating/creating new nodes to align with demand, it is advisable to adhere to the following best practices:
+
+[CoreDNS lameduck duration](https://aws.github.io/aws-eks-best-practices/scalability/docs/cluster-services/#coredns-lameduck-duration)
+
+[CoreDNS readiness probe](https://aws.github.io/aws-eks-best-practices/scalability/docs/cluster-services/#coredns-readiness-probe)
+
+This will ensure that DNS queries are not directed to a CoreDNS Pod that is not yet ready or has been terminated.
+
 ## Additional Resources
 * [Karpenter/Spot Workshop](https://ec2spotworkshops.com/karpenter.html)
 * [Karpenter Node Provisioner](https://youtu.be/_FXRIKWJWUk)

--- a/content/scalability/docs/cluster-services.md
+++ b/content/scalability/docs/cluster-services.md
@@ -57,6 +57,22 @@ You can reduce DNS lookup failures by setting a [lameduck](https://coredns.io/pl
 
 We recommend setting CoreDNS lameduck duration to 30 seconds. 
 
+## CoreDNS readiness probe
+
+We recommend using /ready instead of /health on on readiness probe of CoreDNS.
+
+In alignment with the earlier recommendation to set the lameduck duration to 30 seconds, providing ample time for the node's iptables rules to be updated before pod termination, employing /ready instead of /health for the CoreDNS readiness probe ensures that the CoreDNS pod is fully prepared during startup to promptly respond to DNS requests.
+
+```
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8181
+    scheme: HTTP
+```
+
+For more information about the CoreDNS Ready plugin please refer to https://coredns.io/plugins/ready/
+
 ## Logging and monitoring agents
 
 Logging and monitoring agents can add significant load to your cluster control plane because the agents query the API server to enrich logs and metrics with workload metadata. The agent on a node only has access to the local node resources to see things like container and process name. Querying the API server it can add more details such as Kubernetes deployment name and labels. This can be extremely helpful for troubleshooting but detrimental to scaling.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[add recommendation for CoreDNS readiness probe](https://github.com/aws/aws-eks-best-practices/commit/303f9b94397e9930eb01444f48326187d7f91366)
[add recommendation when deploying CoreDNS pods on nodes managed by Karpenter](https://github.com/aws/aws-eks-best-practices/commit/1ccd0f90a699fb30c8e1de6be2c57805866ba19a)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
