### PR TITLE
Command error for getting CoreDNS pod logs

### DIFF
--- a/content/reliability/docs/dataplane.md
+++ b/content/reliability/docs/dataplane.md
@@ -220,7 +220,7 @@ CoreDNS has built in support for [Prometheus](https://github.com/coredns/coredns
 For troubleshooting purposes, you can use kubectl to view CoreDNS logs:
 
 ```shell
-for p in $(kubectl get pods —namespace=kube-system -l k8s-app=kube-dns -o name); do kubectl logs —namespace=kube-system $p; done
+for p in $(kubectl get pods -n kube-system -l k8s-app=kube-dns -o jsonpath='{.items[*].metadata.name}'); do kubectl logs $p -n kube-system; done
 ```
 
 ### Use NodeLocal DNSCache


### PR DESCRIPTION
Fix the command for getting CoreDNS pod logs

*Issue #, if available:*

Current command have multiple typo:

1) -namespace -> --namespace
2) "-o name" couldn't be used when selector specific. Will get following error message:

`error: name cannot be provided when a selector is specified
`
*Description of changes:*

Modify the command and testing on my env successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
