### PR TITLE
Exclude non-repo GH URLs from link scanning

### DIFF
--- a/.github/actions/linkbot/linkbot/github.py
+++ b/.github/actions/linkbot/linkbot/github.py
@@ -17,7 +17,9 @@ class Client:
 
     @staticmethod
     def repo_full_name_from_url(url):
-        return re.search(r"github.com/([^/]+/[^/]+)", url).group(1)
+        match = re.search(r"github.com/([^/]+/[^/]+)", url)
+        if match:
+            return match.group(1)
 
     @staticmethod
     def latest_commit_date_on_default_branch(repo):

--- a/.github/actions/linkbot/linkbot/github.py
+++ b/.github/actions/linkbot/linkbot/github.py
@@ -6,6 +6,11 @@ from github import Auth, Github
 from .checks import RepoStats
 
 
+def repo_full_name_from_url(url):
+    match = re.search(r"github.com/([^/]+/[^/]+)", url)
+    if match:
+        return match.group(1)
+
 class Client:
 
     def __init__(self, token=None):
@@ -16,17 +21,11 @@ class Client:
             self._pygh = Github()
 
     @staticmethod
-    def repo_full_name_from_url(url):
-        match = re.search(r"github.com/([^/]+/[^/]+)", url)
-        if match:
-            return match.group(1)
-
-    @staticmethod
     def latest_commit_date_on_default_branch(repo):
         return repo.get_commits()[0].commit.author.date
     
     def get_repo_stats(self, url):
-        full_name = self.repo_full_name_from_url(url)
+        full_name = repo_full_name_from_url(url)
         repo = self._pygh.get_repo(full_name)
         return RepoStats(
             # Keeping the original name/URL here rather than the one from the API
@@ -45,12 +44,12 @@ class Client:
 
 
     def get_open_issue_messages(self, repo_url, user):
-        full_name = self.repo_full_name_from_url(repo_url)
+        full_name = repo_full_name_from_url(repo_url)
         repo = self._pygh.get_repo(full_name)
         return [issue.body for issue in repo.get_issues(state='open', creator=user)]
 
 
     def create_issue(self, repo_url, title, body):
-        full_name = self.repo_full_name_from_url(repo_url)
+        full_name = repo_full_name_from_url(repo_url)
         repo = self._pygh.get_repo(full_name)
         return repo.create_issue(title, body)

--- a/.github/actions/linkbot/linkbot/links.py
+++ b/.github/actions/linkbot/linkbot/links.py
@@ -1,5 +1,7 @@
 import re
 
+from .github import repo_full_name_from_url
+
 
 def find_links_in_markdown(markdown):
     '''Takes a markdown string and returns a list of links'''
@@ -7,7 +9,7 @@ def find_links_in_markdown(markdown):
 
 
 def is_github_url(link):
-    return bool(re.match(r"https?://github\.com.*", link))
+    return bool(repo_full_name_from_url(link))
 
 
 def github_links_in_files(path, glob):

--- a/.github/actions/linkbot/tests/data/markdown/child1/blah.md
+++ b/.github/actions/linkbot/tests/data/markdown/child1/blah.md
@@ -1,1 +1,3 @@
 Here's [a link](https://github.com/kubernetes/kubernetes).
+
+This is [not a repo](https://github.com/FairwindsOps/).

--- a/.github/actions/linkbot/tests/test_github.py
+++ b/.github/actions/linkbot/tests/test_github.py
@@ -4,13 +4,12 @@ import os
 import pytest
 
 from linkbot.checks import RepoStats
-from linkbot.github import Client
+from linkbot.github import Client, repo_full_name_from_url
 
 
 def test_repo_name_from_url():
-    gh = Client(os.environ.get('LINKBOT_GH_TOKEN'))
-    assert (gh.repo_full_name_from_url('https://github.com/bellkev/ToneBoard') == 'bellkev/ToneBoard')
-    assert (gh.repo_full_name_from_url('https://github.com/FairwindsOps/') == None)
+    assert (repo_full_name_from_url('https://github.com/bellkev/ToneBoard') == 'bellkev/ToneBoard')
+    assert (repo_full_name_from_url('https://github.com/FairwindsOps/') == None)
 
 
 @pytest.mark.network

--- a/.github/actions/linkbot/tests/test_github.py
+++ b/.github/actions/linkbot/tests/test_github.py
@@ -10,6 +10,7 @@ from linkbot.github import Client
 def test_repo_name_from_url():
     gh = Client(os.environ.get('LINKBOT_GH_TOKEN'))
     assert (gh.repo_full_name_from_url('https://github.com/bellkev/ToneBoard') == 'bellkev/ToneBoard')
+    assert (gh.repo_full_name_from_url('https://github.com/FairwindsOps/') == None)
 
 
 @pytest.mark.network


### PR DESCRIPTION
This resolves an issue that occurs now for URLs like `https://github.com/FairwindsOps/`. The scanning for external GH repos will now only look for links that can be resolved as repo URLs (as opposed to orgs).