### PR TITLE
Update Karpenter index.md

### DIFF
--- a/content/karpenter/index.md
+++ b/content/karpenter/index.md
@@ -114,7 +114,8 @@ com.amazonaws.<region>.ecr.api
 com.amazonaws.<region>.ecr.dkr
 com.amazonaws.<region>.s3 – For pulling container images
 com.amazonaws.<region>.sts – For IAM roles for service accounts
-com.amazonaws.<region>.ssm - If using Karpenter
+com.amazonaws.<region>.ssm - For resolving default AMIs
+com.amazonaws.<region>.sqs - For accessing SQS if using interruption handling
 ```
 
 !!! note


### PR DESCRIPTION
Updated VPC Endpoints required by Karpenter when deployed to a private EKS cluster based on latest Karpenter documentation, https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#private-clusters.

*Issue #, if available:*

*Description of changes:* Karpenter documentation for latest release indicates additional VPC Endpoints then what is currently covered in this guide.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
