### PR TITLE
Fix Cluster Autoscaler IAM policy

### DIFF
--- a/content/cluster-autoscaling/index.md
+++ b/content/cluster-autoscaling/index.md
@@ -64,13 +64,16 @@ This will prevents a Cluster Autoscaler running in one cluster from modifying no
         {
             "Effect": "Allow",
             "Action": [
-                "autoscaling:DescribeAutoScalingInstances",
                 "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeScalingActivities",
-                "ec2:DescribeLaunchTemplateVersions",
-                "autoscaling:DescribeTags",
+                "autoscaling:DescribeAutoScalingInstances",
                 "autoscaling:DescribeLaunchConfigurations",
-                "ec2:DescribeInstanceTypes"
+                "autoscaling:DescribeScalingActivities",
+                "autoscaling:DescribeTags",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeLaunchTemplateVersions",
+                "ec2:GetInstanceTypesFromInstanceRequirements",
+                "eks:DescribeNodegroup"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
*Issue #322 

*Description of changes:*

Add the missing action "eks:DescribeNodegroup" to the IAM policy of the Cluster Autoscaler.

Additionally, all actions within the policy are sorted alphabetically for better readability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
