### PR TITLE
Add K8s SLO details and expand common quotas/limits 

### DIFF
--- a/content/reliability/docs/controlplane.md
+++ b/content/reliability/docs/controlplane.md
@@ -191,14 +191,6 @@ EKS actively monitors the load on control plane instances and automatically scal
 - Clusters with more than 1000 services may experience network latency with using `kube-proxy` in `iptables` mode according to the [tests performed by the ProjectCalico team](https://www.projectcalico.org/comparing-kube-proxy-modes-iptables-or-ipvs/). The solution is to switch to [running `kube-proxy` in `ipvs` mode](https://medium.com/@jeremy.i.cowan/the-problem-with-kube-proxy-enabling-ipvs-on-eks-169ac22e237e).
 - You may also experience [EC2 API request throttling](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html) if the CNI needs to request IP addresses for Pods or if you need to create new EC2 instances frequently. You can reduce calls EC2 API by configuring the CNI to cache IP addresses. You can use larger EC2 instance types to reduce EC2 scaling events.
 
-## Know limits and service quotas
-
-AWS sets service limits (an upper limit on the number of each resource your team can request) to protect you from accidentally over-provisioning resources. [Amazon EKS Service Quotas](https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) lists the service limits. There are two types of limits, soft limits, that can be changed using [AWS Service Quotas](https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html). Hard limits cannot be changed. You should consider these values when architecting your applications. Consider reviewing these service limits periodically and incorporate them during in your application design.
-
-- Besides the limits from orchestration engines, there are limits in other AWS services, such as Elastic Load Balancing (ELB) and Amazon VPC, that may affect your application performance.
-- More about EC2 limits here: [EC2 service limits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html).
-- Each EC2 instance limits the number of packets that can be sent to the [Amazon-provided DNS server](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-limits) to a maximum of 1024 packets per second per network interface.
-- In EKS environment, etcd storage limit is **8 GiB** as per [upstream guidance](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit). Please monitor metric `etcd_db_total_size_in_bytes` to track etcd db size. You can refer to [alert rules](https://github.com/etcd-io/etcd/blob/main/contrib/mixin/mixin.libsonnet#L213-L240) `etcdBackendQuotaLowSpace` and `etcdExcessiveDatabaseGrowth` to setup this monitoring.
 
 ## Additional Resources:
 

--- a/content/scalability/docs/kubernetes-slos.md
+++ b/content/scalability/docs/kubernetes-slos.md
@@ -1,0 +1,142 @@
+# Kubernetes Upstream SLOs
+
+Amazon EKS runs the same code as the upstream Kubernetes releases and ensures that EKS clusters operate within the SLOs defined by the Kubernetes community. The Kubernetes[Scalability Special Interest Group (SIG)](https://github.com/kubernetes/community/tree/master/sig-scalability) defines the scalability goals and investigates bottlenecks in performance through SLIs and SLOs. 
+
+Kubernetes has a number of features that allow users to extend the system with custom add-ons or drivers, like CSI drivers, admission webhooks, and auto-scalers. These extensions can drastically impact the performance of a Kubernetes cluster in different ways, i.e. an admission webhook with `failurePolicy=Ignore` could add latency to K8s API requests if the webhook target is unavailable. The Kubernetes Scalability SIG defines scalability using a ["you promise, we promise" framework](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md#how-we-define-scalability):
+
+
+> If you promise to:  
+>     - correctly configure your cluster  
+>     - use extensibility features "reasonably"  
+>     - keep the load in the cluster within [recommended limits](https://github.com/kubernetes/community/blob/master/sig-scalability/configs-and-limits/thresholds.md)  
+> 
+> then we promise that your cluster scales, i.e.:  
+>     - all the SLOs are satisfied.   
+
+## Kubernetes SLOs
+The Kubernetes SLOs don’t account for all of the plugins and external limitations that could impact a cluster, such as worker node scaling or admission webhooks. These SLOs focus on [Kubernetes components](https://kubernetes.io/docs/concepts/overview/components/) and ensure that Kubernetes actions and resources are operating within expectations. The SLOs help Kubernetes developers ensure that changes to Kubernetes code do not degrade performance for the entire system.
+
+The [Kuberntes Scalability SIG defines the following official SLO/SLIs](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md). The Amazon EKS team regularly runs scalability tests on EKS clusters for these SLOs/SLIs to monitor for performance degradation as changes are made and new versions are released.
+
+
+|Objective	|Definition	|SLO	|
+|---	|---	|---	|
+|API request latency (mutating)	|Latency of processing mutating  API calls for single objects for every (resource, verb) pair, measured as 99th percentile over last 5 minutes	|In default Kubernetes installation, for every (resource, verb) pair, excluding virtual and aggregated resources and Custom Resource Definitions, 99th percentile per cluster-day <= 1s	|
+|API request latency (read-only)	|Latency of processing non-streaming read-only API calls for every (resource, scope) pair, measured as 99th percentile over last 5 minutes	|In default Kubernetes installation, for every (resource, scope) pair, excluding virtual and aggregated resources and Custom Resource Definitions, 99th percentile per cluster-day: (a) <= 1s if `scope=resource` (b) <= 30s otherwise (if `scope=namespace` or `scope=cluster`)	|
+|Pod startup latency	|Startup latency of schedulable stateless pods, excluding time to pull images and run init containers, measured from pod creation timestamp to when all its containers are reported as started and observed via watch, measured as 99th percentile over last 5 minutes	|In default Kubernetes installation, 99th percentile per cluster-day <= 5s	|
+
+### API Request Latency 
+
+The `kube-apiserver` has `--request-timeout` defined as `1m0s` by default, which means a request can run for up to one minute (60 seconds) before being timed out and cancelled. The SLOs defined for Latency are broken out by the type of request that is being made, which can be mutating or read-only:
+
+#### Mutating
+
+Mutating requests in Kubernetes make changes to a resource, such as creations, deletions, or updates. These requests are expensive because those changes must be written to [the etcd backend](https://kubernetes.io/docs/concepts/overview/components/#etcd) before the updated object is returned. [Etcd](https://etcd.io/) is a distributed key-value store that is used for all Kubernetes cluster data.
+
+This latency is measured as the 99th percentile over 5min for (resource, verb) pairs of Kubernetes resources, for example this would measure the latency for Create Pod requests and Update Node requests. The request latency must be <= 1 second to satisfy the SLO.
+
+#### Read-only
+
+Read-only requests retrieve a single resource (such as Get Pod X) or a collection (such as “Get all Pods from Namespace X”). The `kube-apiserver` maintains a cache of objects, so the requested resources may be returned from cache or they may need to be retrieved from etcd first. 
+These latencies are also measured by the 99th percentile over 5 minutes, however read-only requests can have separate scopes. The SLO defines two different objectives:
+
+* For requests made for a *single* resource (i.e. `kubectl get pod -n mynamespace my-controller-xxx` ), the request latency should remain <= 1 second.
+* For requests that are made for multiple resources in a namespace or a cluster (for example, `kubectl get pods -A`) the latency should remain <= 30 seconds
+
+The SLO has different target values for different request scopes because requests made for a list of Kubernetes resources expect the details of all objects in the request to be returned within the SLO. On large clusters, or large collections of resources, this can result in large response sizes which can take some time to return. For example, in a cluster running tens of thousands of Pods with each Pod being roughly 1 KiB when encoded in JSON, returning all Pods in the cluster would consist of 10MB or more. Kubernetes clients can help reduce this response size [using APIListChunking to retrieve large collections of resources](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks). 
+
+### Pod Startup Latency
+
+This SLO is primarily concerned with the time it takes from Pod creation to when the containers in that Pod actually begin execution. To measure this the difference from the creation timestamp recorded on the Pod, and when [a WATCH on that Pod](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) reports the containers have started is calculated (excluding time for container image pulls and init container execution). To satisfy the SLO the 99th percentile per cluster-day of this Pod Startup Latency must remain <=5 seconds. 
+
+Note that this SLO assumes that the worker nodes already exist in this cluster in a ready state for the Pod to be scheduled on. This SLO does not account for image pulls or init container executions, and also limits the test to “stateless pods” which don’t leverage persistent storage plugins. 
+
+## Kubernetes SLI Metrics 
+
+Kubernetes is also improving the Observability around the SLIs by adding [Prometheus metrics](https://prometheus.io/docs/concepts/data_model/) to Kubernetes components that track these SLIs over time. Using [Prometheus Query Language (PromQL)](https://prometheus.io/docs/prometheus/latest/querying/basics/) we can build queries that display the SLI performance over time in tools like Prometheus or Grafana dashboards, below are some examples for the SLOs above.
+
+### API Server Request Latency
+
+|Metric	|Definition	|
+|---	|---	|
+|apiserver_request_sli_duration_seconds	| Response latency distribution (not counting webhook duration and priority & fairness queue wait times) in seconds for each verb, group, version, resource, subresource, scope and component.	|
+|apiserver_request_duration_seconds	| Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component.	|  
+
+*Note: The `apiserver_request_sli_duration_seconds` metric is available starting in Kubernetes 1.27.*
+
+You can use these metrics to investigate the API Server response times and if there are bottlenecks in the Kubernetes components or other plugins/components. The queries below are based on [the community SLO dashboard](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2/pkg/prometheus/manifests/dashboards). 
+
+**API Request latency SLI (mutating)** - this time does *not* include webhook execution or time waiting in queue.   
+`histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket{verb=~"CREATE|DELETE|PATCH|POST|PUT", subresource!~"proxy|attach|log|exec|portforward"}[5m])) by (resource, subresource, verb, scope, le)) > 0`
+
+**API Request latency Total (mutating)** - this is the total time the request took on the API server, this time may be longer than the SLI time because it includes webhook execution and API Priority and Fairness wait times.  
+`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CREATE|DELETE|PATCH|POST|PUT", subresource!~"proxy|attach|log|exec|portforward"}[5m])) by (resource, subresource, verb, scope, le)) > 0`
+
+In these queries we are excluding the streaming API requests which do not return immediately, such as `kubectl port-forward` or `kubectl exec` requests (`subresource!~"proxy|attach|log|exec|portforward"`), and we are filtering for only the Kubernetes verbs that modify objects (`verb=~"CREATE|DELETE|PATCH|POST|PUT"`). We are then calculating the 99th percentile of that latency over the last 5 minutes.
+
+We can use a similar query for the read only API requests, we simply modify the verbs we’re filtering for to include the Read only actions `LIST` and `GET`. There are also different SLO thresholds depending on the scope of the request, i.e. getting a single resource or listing a number of resources.
+
+**API Request latency SLI  (read-only)** - this time does *not* include webhook execution or time waiting in queue.
+For a single resource (scope=resource, threshold=1s)  
+`histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket{verb=~"GET", scope=~"resource"}[5m])) by (resource, subresource, verb, scope, le))`
+
+For a collection of resources in the same namespace (scope=namespace, threshold=5s)  
+`histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket{verb=~"LIST", scope=~"namespace"}[5m])) by (resource, subresource, verb, scope, le))`
+
+For a collection of resources across the entire cluster (scope=cluster, threshold=30s)  
+`histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket{verb=~"LIST", scope=~"cluster"}[5m])) by (resource, subresource, verb, scope, le))`
+
+**API Request latency Total (read-only)** - this is the total time the request took on the API server, this time may be longer than the SLI time because it includes webhook execution and wait times.
+For a single resource (scope=resource, threshold=1s)  
+`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"GET", scope=~"resource"}[5m])) by (resource, subresource, verb, scope, le))`
+
+For a collection of resources in the same namespace (scope=namespace, threshold=5s)  
+`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"LIST", scope=~"namespace"}[5m])) by (resource, subresource, verb, scope, le))`
+
+For a collection of resources across the entire cluster (scope=cluster, threshold=30s)  
+`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"LIST", scope=~"cluster"}[5m])) by (resource, subresource, verb, scope, le))`
+
+The SLI metrics provide insight into how Kubernetes components are performing by excluding the time that requests spend waiting in API Priority and Fairness queues, working through admission webhooks, or other Kubernetes extensions. The total metrics provide a more holistic view as it reflects the time your applications would be waiting for a response from the API server. Comparing these metrics can provide insight into where the delays in request processing are being introduced. 
+
+### Pod Startup Latency
+
+|Metric	| Definition	|
+|---	|---	|
+|kubelet_pod_start_sli_duration_seconds	|Duration in seconds to start a pod, excluding time to pull images and run init containers, measured from pod creation timestamp to when all its containers are reported as started and observed via watch	|
+|kubelet_pod_start_duration_seconds	|Duration in seconds from kubelet seeing a pod for the first time to the pod starting to run. This does not include the time to schedule the pod or scale out worker node capacity.	|
+
+*Note:  `kubelet_pod_start_sli_duration_seconds` is available starting in Kubernetes 1.27.*
+
+Similar to the queries above you can use these metrics to gain insight into how long node scaling, image pulls and init containers are delaying the pod launch compared to Kubelet actions. 
+
+**Pod startup latency SLI -** this is the time from the pod being created to when the application containers reported as running. This includes the time it takes for the worker node capacity to be available and the pod to be scheduled, but this does not include the time it takes to pull images or for the init containers to run.  
+`histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (le))`
+
+**Pod startup latency Total -** this is the time it takes the kubelet to start the pod for the first time. This is measured from when the kubelet recieves the pod via WATCH, which does not include the time for worker node scaling or scheduling. This includes the time to pull images and init containers to run.  
+`histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (le))`
+
+
+
+## SLOs on Your Cluster
+
+If you are collecting the Prometheus metrics from the Kubernetes resources in your EKS cluster you can gain deeper insights into the performance of the Kubernetes control plane components. 
+
+The [perf-tests repo](https://github.com/kubernetes/perf-tests/) includes Grafana dashboards that display the latencies and critical performance metrics for the cluster during tests. The perf-tests configuration leverages the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), an open source project that comes configured to collect Kubernetes metrics, but you can also [use Amazon Managed Prometheus and Amazon Managed Grafana.](https://aws-observability.github.io/terraform-aws-observability-accelerator/eks/)
+
+If you are using the `kube-prometheus-stack` or similar Prometheus solution you can install the same dashboard to observe the SLOs on your cluster in real time. 
+
+1. You will first need to install the Prometheus Rules that are used in the dashboards with `kubectl apply -f prometheus-rules.yaml`. You can download a copy of the rules here: https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+    1. Be sure to check the namespace in the file matches your environment
+    2. Verify that the labels match the `prometheus.prometheusSpec.ruleSelector` helm value if you are using `kube-prometheus-stack`
+2. You can then install the dashboards in Grafana. The json dashboards and python scripts to generate them are available here: https://github.com/kubernetes/perf-tests/tree/master/clusterloader2/pkg/prometheus/manifests/dashboards
+    1. [the `slo.json` dashboard](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/prometheus/manifests/dashboards/slo.json) displays the performance of the cluster in relation to the Kubernetes SLOs
+
+Consider that the SLOs are focused on the performance of the Kubernetes components in your clusters, but there are additional metrics you can review which provide different perspectives or insights in to your cluster. Kubernetes community projects like [Kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/main) can help you quickly analyze trends in your cluster. Most common plugins and drivers from the Kubernetes community also emit Prometheus metrics, allowing you to investigate things like autoscalers or custom schedulers.  
+
+The [Observability Best Practices Guide](https://aws-observability.github.io/observability-best-practices/guides/containers/oss/eks/best-practices-metrics-collection/#control-plane-metrics) has examples of other Kubernetes metrics you can use to gain further insight. 
+
+
+
+
+
+

--- a/content/scalability/docs/kubernetes_slos.md
+++ b/content/scalability/docs/kubernetes_slos.md
@@ -2,6 +2,8 @@
 
 Amazon EKS runs the same code as the upstream Kubernetes releases and ensures that EKS clusters operate within the SLOs defined by the Kubernetes community. The Kubernetes[Scalability Special Interest Group (SIG)](https://github.com/kubernetes/community/tree/master/sig-scalability) defines the scalability goals and investigates bottlenecks in performance through SLIs and SLOs. 
 
+SLIs are how we measure a system like metrics or measures that can be used to determine how “well” the system is running, e.g. request latency or count. SLOs define the values that are expected for when the system is running “well”, e.g. request latency remains less than 3 seconds. The Kubernetes SLOs and SLIs focus on the performance of the Kubernetes components and are completely independent from the Amazon EKS Service SLAs which focus on availability of the EKS cluster endpoint.
+
 Kubernetes has a number of features that allow users to extend the system with custom add-ons or drivers, like CSI drivers, admission webhooks, and auto-scalers. These extensions can drastically impact the performance of a Kubernetes cluster in different ways, i.e. an admission webhook with `failurePolicy=Ignore` could add latency to K8s API requests if the webhook target is unavailable. The Kubernetes Scalability SIG defines scalability using a ["you promise, we promise" framework](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md#how-we-define-scalability):
 
 

--- a/content/scalability/docs/quotas.md
+++ b/content/scalability/docs/quotas.md
@@ -1,0 +1,85 @@
+# Known Limits and Service Quotas
+Amazon EKS can be used for a variety of workloads and can interact with a wide range of AWS services, and we have seen customer workloads encounter a similar range of AWS service quotas and other issues that hamper scalability. 
+
+Your AWS account has default quotas (an upper limit on the number of each AWS resource your team can request). Each AWS service defines their own quota, and quotas are generally region-specific. You can request increases for some quotas (soft limits), and other quotas cannot be increased (hard limits). You should consider these values when architecting your applications. Consider reviewing these service limits periodically and incorporate them during in your application design.
+
+You can review the usage in your account and open a quota increase request at the [AWS Service Quotas console](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#request-increase), or using [the AWS CLI](https://repost.aws/knowledge-center/request-service-quota-increase-cli). Refer to the AWS documentation from the respective AWS Service for more details on the Service Quotas and any further restrictions or notices on their increase.
+
+
+!!! note
+    [Amazon EKS Service Quotas](https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) lists the service quotas and has links to request increases where available.
+
+
+## Other AWS Service Quotas 
+We have seen EKS customers impacted by the quotas listed below for other AWS services. Some of these may only apply to specific use cases or configurations, however you may consider if your solution will encounter any of these as it scales. The Quotas are organized by Service and each Quota has an ID in the format of L-XXXXXXXX you can use to look it up in the [AWS Service Quotas console](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html#request-increase)
+
+
+| Service        | Quota (L-xxxxx)                                                                            | **Impact**                                                                                                         | **ID (L-xxxxx)** | default |
+| -------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ---------------- | ------- |
+| IAM            | Roles per account                                                                          | Can limit the number of clusters or IRSA roles in an account.                                                      | L-FE177D64       | 1,000   |
+| IAM            | OpenId connect providers per account                                                       | Can limit the number of Clusters per account, OpenID Connect is used by IRSA                                       | L-858F3967       | 100     |
+| IAM            | Role trust policy length                                                                   | Can limit the number of of clusters an IAM role is associated with for IRSA                                        | L-C07B4B0D       | 2,048   |
+| VPC            | Security groups per network interface                                                      | Can limit the control or connectivity of the networking for your cluster                                           | L-2AFB9258       | 5       |
+| VPC            | IPv4 CIDR blocks per VPC                                                                   | Can limit the number of EKS Worker Nodes                                                                           | L-83CA0A9D       | 5       |
+| VPC            | Routes per route table                                                                     | Can limit the control or connectivity of the networking for your cluster                                           | L-93826ACB       | 50      |
+| VPC            | Active VPC peering connections per VPC                                                     | Can limit the control or connectivity of the networking for your cluster                                           | L-7E9ECCDB       | 50      |
+| VPC            | Inbound or outbound rules per security group.                                              | Can limit the control or connectivity of the networking for your cluster, some controllers in EKS create new rules | L-0EA8095F       | 50      |
+| VPC            | VPCs per Region                                                                            | Can limit the number of Clusters per account or the control or connectivity of the networking for your cluster     | L-F678F1CE       | 5       |
+| VPC            | Internet gateways per Region                                                               | Can limit the number of Clusters per account or the control or connectivity of the networking for your cluster     | L-A4707A72       | 5       |
+| VPC            | Network interfaces per Region                                                              | Can limit the number of EKS Worker nodes, or Impact EKS control plane scaling/update activities.                   | L-DF5E4CA3       | 5,000   |
+| VPC            | Network Address Usage                                                                      | Can limit the number of Clusters per account or the control or connectivity of the networking for your cluster     | L-BB24F6E5       | 64,000  |
+| VPC            | Peered Network Address Usage                                                               | Can limit the number of Clusters per account or the control or connectivity of the networking for your cluster     | L-CD17FD4B       | 128,000 |
+| ELB            | Listeners per Network Load Balancer                                                        | Can limit the control of traffic ingress to the cluster.                                                           | L-57A373D6       | 50      |
+| ELB            | Target Groups per Region                                                                   | Can limit the control of traffic ingress to the cluster.                                                           | L-B22855CB       | 3,000   |
+| ELB            | Targets per Application Load Balancer                                                      | Can limit the control of traffic ingress to the cluster.                                                           | L-7E6692B2       | 1,000   |
+| ELB            | Targets per Network Load Balancer                                                          | Can limit the control of traffic ingress to the cluster.                                                           | L-EEF1AD04       | 3,000   |
+| ELB            | Targets per Availability Zone per Network Load Balancer                                    | Can limit the control of traffic ingress to the cluster.                                                           | L-B211E961       | 500     |
+| ELB            | Targets per Target Group per Region                                                        | Can limit the control of traffic ingress to the cluster.                                                           | L-A0D0B863       | 1,000   |
+| ELB            | Application Load Balancers per Region                                                      | Can limit the control of traffic ingress to the cluster.                                                           | L-53DA6B97       | 50      |
+| ELB            | Classic Load Balancers per Region                                                          | Can limit the control of traffic ingress to the cluster.                                                           | L-E9E9831D       | 20      |
+| ELB            | Network Load Balancers per Region                                                          | Can limit the control of traffic ingress to the cluster.                                                           | L-69A177A2       | 50      |
+| EC2            | Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances (as a maximum vCPU count) | Can limit the number of EKS Worker Nodes                                                                           | L-1216C47A       | 5       |
+| EC2            | All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests (as a maximum vCPU count)  | Can limit the number of EKS Worker Nodes                                                                           | L-34B43A08       | 5       |
+| EC2            | EC2-VPC Elastic IPs                                                                        | Can limit the number of NAT GWs (and thus VPCs), which may limit the number of clusters in a region                | L-0263D0A3       | 5       |
+| EBS            | Snapshots per Region                                                                       | Can limit the backup strategy for stateful workloads                                                               | L-309BACF6       | 100,000 |
+| EBS            | Storage for General Purpose SSD (gp3) volumes, in TiB                                      | Can limit the number of EKS Worker Nodes, or PersistentVolume storage                                              | L-7A658B76       | 50      |
+| EBS            | Storage for General Purpose SSD (gp2) volumes, in TiB                                      | Can limit the number of EKS Worker Nodes,  or PersistentVolume storage                                             | L-D18FCD1D       | 50      |
+| ECR            | Registered repositories                                                                    | Can limit the number of workloads in your clusters                                                                 | L-CFEB8E8D       | 10,000  |
+| ECR            | Images per repository                                                                      | Can limit the number of workloads in your clusters                                                                 | L-03A36CE1       | 10,000  |
+| SecretsManager | Secrets per Region                                                                         | Can limit the number of workloads in your clusters                                                                 | L-2F66C23C       | 500,000 |
+
+
+## AWS Request Throttling
+
+AWS services also implement request throttling to ensure that they remain performant and available for all customers. Simliar to Service Quotas, each AWS service maintains their own request throttling thresholds. Consider reviewing the respective AWS Service documentation if your workloads will need to quickly issue a large number of API calls or if you notice request throttling errors in your application. 
+
+EC2 API requests around provisioning EC2 network interfaces or IP addresses can encounter request throttling in large clusters or when clusters scale drastically. The table below shows some of the API actions that we have seen customers encounter request throttling from.
+You can review the EC2 rate limit defaults and the steps to request a rate limit increase in the [EC2 documentation on Rate Throttling](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html).
+
+
+| Mutating Actions                | Read-only Actions               |
+| ------------------------------- | ------------------------------- |
+| AssignPrivateIpAddresses        | DescribeDhcpOptions             |
+| AttachNetworkInterface          | DescribeInstances               |
+| CreateNetworkInterface          | DescribeNetworkInterfaces       |
+| DeleteNetworkInterface          | DescribeSecurityGroups          |
+| DeleteTags                      | DescribeTags                    |
+| DetachNetworkInterface          | DescribeVpcs                    |
+| ModifyNetworkInterfaceAttribute | DescribeVolumes                 |
+| UnassignPrivateIpAddresses      |                     |
+
+
+
+
+
+## Other Known Limits
+
+* Route 53 DNS resolvers are limited to [1024 Packets per second](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-limits). This limit can be encountered when DNS traffic from a large cluster is funneled through a small number of CoreDNS Pod replicas. [Scaling CoreDNS and optimizing DNS behavior](../cluster-services/#scale-coredns) can avoid timeouts on DNS lookups.
+    * [Route 53 also has a fairly low rate limit of 5 requests per second to the Route 53 API](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests). If you have a large number of domains to update with a project like External DNS you may see rate throttling and delays in updating domains.
+
+* Some [Nitro instance types have a volume attachment limit of 28](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#instance-type-volume-limits) that is shared between Amazon EBS volumes, network interfaces, and NVMe instance store volumes. If your workloads are mounting numerous EBS volumes you may encounter limits to the pod density you can achieve with these instance types
+
+* There is a maximum number of connections that can be tracked per Ec2 instance. [If your workloads are handling a large number of connections you may see communication failures or errors because this maximum has been hit.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-throttling) You can use the `conntrack_allowance_available` and `conntrack_allowance_exceeded` [network performance metrics to monitor the number of tracked connections on your EKS worker nodes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-network-performance-ena.html).
+
+
+* In EKS environment, etcd storage limit is **8 GiB** as per [upstream guidance](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit). Please monitor metric `etcd_db_total_size_in_bytes` to track etcd db size. You can refer to [alert rules](https://github.com/etcd-io/etcd/blob/main/contrib/mixin/mixin.libsonnet#L213-L240) `etcdBackendQuotaLowSpace` and `etcdExcessiveDatabaseGrowth` to setup this monitoring.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,8 @@ nav:
       - The theory behind scaling: "scalability/docs/scaling_theory.md"
       - Control plane monitoring: "scalability/docs/kcp_monitoring.md"
       - Node efficiency and scaling: "scalability/docs/node_efficiency.md"
+      - Kubernetes SLOs: "scalability/docs/kubernetes_slos.md"
+      - Known limits and service quotas: "scalability/docs/quotas.md"
   - Cluster Upgrades: "upgrades/index.md"
   - Cost Optimization:
       - Cloud Financial Management Framework: "cost_optimization/cfm_framework.md"


### PR DESCRIPTION
*Issue #, if available:*
N/A 
*Description of changes:*
This expands the [Know limits andservice quotas](https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#know-limits-and-service-quotas) section into a page under the Scalability section.

I've also added details and promQL that can be used to investigate control plane performance along the lines of the upstream Kubernetes SLOs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.