### PR TITLE
Improve `preBootstrapCommands` commands output

### DIFF
--- a/content/scalability/docs/data-plane.ko.md
+++ b/content/scalability/docs/data-plane.ko.md
@@ -137,11 +137,12 @@ managedNodeGroups:
       - volumeName: '/dev/sdz'
         volumeSize: 100
     preBootstrapCommands:
-      - "systemctl stop containerd"
-      - "mkfs -t ext4 /dev/nvme1n1"
-      - "rm -rf /var/lib/containerd/*"
-      - "mount /dev/nvme1n1 /var/lib/containerd/"
-      - "systemctl start containerd"
+    - |
+      "systemctl stop containerd"
+      "mkfs -t ext4 /dev/nvme1n1"
+      "rm -rf /var/lib/containerd/*"
+      "mount /dev/nvme1n1 /var/lib/containerd/"
+      "systemctl start containerd"
 ```
 
 Terraform을 사용하여 노드 그룹을 프로비저닝하는 경우 [EKS Blueprints for terraform](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/examples/node-groups/main.tf)의 예를 참조하세요. Karpenter를 사용하여 노드를 프로비저닝하는 경우 노드 사용자 데이터와 함께 [`blockDeviceMappings`](https://karpenter.sh/docs/concepts/node-templates/#specblockdevicemappings)를 사용하여 추가 볼륨을 추가할 수 있습니다.

--- a/content/scalability/docs/data-plane.md
+++ b/content/scalability/docs/data-plane.md
@@ -137,11 +137,12 @@ managedNodeGroups:
       - volumeName: '/dev/sdz'
         volumeSize: 100
     preBootstrapCommands:
-      - "systemctl stop containerd"
-      - "mkfs -t ext4 /dev/nvme1n1"
-      - "rm -rf /var/lib/containerd/*"
-      - "mount /dev/nvme1n1 /var/lib/containerd/"
-      - "systemctl start containerd"
+    - |
+      "systemctl stop containerd"
+      "mkfs -t ext4 /dev/nvme1n1"
+      "rm -rf /var/lib/containerd/*"
+      "mount /dev/nvme1n1 /var/lib/containerd/"
+      "systemctl start containerd"
 ```
 
 If you are using terraform to provision your node groups please see examples in [EKS Blueprints for terraform](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/examples/node-groups/managed-node-groups/main.tf). If you are using Karpenter to provision nodes you can use [`blockDeviceMappings`](https://karpenter.sh/docs/concepts/node-templates/#specblockdevicemappings) with node user-data to add additional volumes.


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Improve `preBootstrapCommands` commands output.

### Existing sample would generate `preBootstrapCommands` as follow,

<img width="760" alt="image" src="https://github.com/aws/aws-eks-best-practices/assets/984415/3ee0defa-e662-488b-a37f-6fe0e8ea1671">

### Would be better to have one as follow,

<img width="778" alt="image" src="https://github.com/aws/aws-eks-best-practices/assets/984415/81df25b9-18b4-426f-8032-b955a5957c67">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
