### PR TITLE
Fix terraform example in iam.md

### DIFF
--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -488,7 +488,7 @@ If you are using Terraform to create launch templates for use with Managed Node 
 resource "aws_launch_template" "foo" {
   name = "foo"
   ...
-    metadata_options {
+    metadata_options = {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Terraform example on line 491 was missing a '='

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
