### PR TITLE
Fix link to Karpenter docs

### DIFF
--- a/content/cost_optimization/cost_opt_compute.md
+++ b/content/cost_optimization/cost_opt_compute.md
@@ -158,7 +158,7 @@ spec:
 
 AWS resource [tags](https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html) are used to organize your resources, and to track your AWS costs on a detailed level. They do not directly correlate with Kubernetes labels for cost tracking. It’s recommended to start with Kubernetes resource labeling and utilize tools like [Kubecost](https://aws.amazon.com/blogs/containers/aws-and-kubecost-collaborate-to-deliver-cost-monitoring-for-eks-customers/) to get infrastructure cost reporting based on Kubernetes labels on pods, namespaces etc.
 
-Worker nodes need to have tags to show billing information in AWS Cost Explorer. With Cluster Autoscaler, tag your worker nodes inside a managed node group using [launch template](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html). For self managed node groups, tag your instances using [EC2 auto scaling group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-tagging.html). For instances provisioned by Karpenter, tag them using [spec.tags in the node template](https://karpenter.sh/v0.29/concepts/node-templates/#spectags).
+Worker nodes need to have tags to show billing information in AWS Cost Explorer. With Cluster Autoscaler, tag your worker nodes inside a managed node group using [launch template](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html). For self managed node groups, tag your instances using [EC2 auto scaling group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-tagging.html). For instances provisioned by Karpenter, tag them using [spec.tags in the node template](https://karpenter.sh/docs/concepts/nodeclasses/#spectags).
 
 ### Multi-tenant clusters
 

--- a/content/upgrades/index.md
+++ b/content/upgrades/index.md
@@ -98,7 +98,7 @@ See the following examples of common add-ons and their relevant upgrade document
 * **Amazon Elastic File System (Amazon EFS) Container Storage Interface (CSI) driver:** For installation and upgrade information, see [Amazon EFS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html).
 * **Kubernetes Metrics Server:** For more information, see [metrics-server](https://kubernetes-sigs.github.io/metrics-server/) on GitHub.
 * **Kubernetes Cluster Autoscaler****:** To upgrade the version of Kubernetes Cluster Autoscaler, change the version of the image in the deployment. The Cluster Autoscaler is tightly coupled with the Kubernetes scheduler. You will always need to upgrade it when you upgrade the cluster. Review the [GitHub releases](https://github.com/kubernetes/autoscaler/releases) to find the address of the latest release corresponding to your Kubernetes minor version.
-* **Karpenter:** For installation and upgrade information, see the [Karpenter documentation.](https://karpenter.sh/v0.27.3/faq/#which-versions-of-kubernetes-does-karpenter-support)
+* **Karpenter:** For installation and upgrade information, see the [Karpenter documentation.](https://karpenter.sh/docs/faq/#which-versions-of-kubernetes-does-karpenter-support)
 
 ## Verify basic EKS requirements before upgrading
 


### PR DESCRIPTION
As:
- old versions v0.27.x & v0.29 are deprecated, corresponding docs are in 404
- concepts still relevant (no need to replace node-templates by nodeclasses everwherein this guide, a redirect is in place)
- all other ~30 references are using the latest doc link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
