### PR TITLE
Update index.md to remove the IMDSv2 not supported on EKS IPv6 sectio…

### DIFF
--- a/content/networking/ipv6/index.md
+++ b/content/networking/ipv6/index.md
@@ -106,6 +106,3 @@ EKS supports IPv6 for Pods running on Fargate. Pods running on Fargate will cons
 
 AWS Network Load Balancer does not support dual-stack UDP protocol address types. If you have strong requirements for low-latency, real-time streaming, online gaming, and IoT, we recommend running IPv4 clusters. To learn more about managing health checks for UDP services, please refer to [“How to route UDP traffic into Kubernetes”](https://aws.amazon.com/blogs/containers/how-to-route-udp-traffic-into-kubernetes/).
 
-### Identify Dependencies on IMDSv2
-
-EKS in IPv6 mode does not support IMDSv2 endpoints (yet). Please open a support ticket if IMDSv2 is a blocker for you to migrate to EKS/IPv6.


### PR DESCRIPTION
…n as it is now supported.

*Issue #, if available:*
https://github.com/aws/aws-eks-best-practices/issues/491

*Description of changes:*

Updated index.md file under networking->ipv6 section. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
