### PR TITLE
fix karpenter annotation doc

### DIFF
--- a/content/karpenter/index.md
+++ b/content/karpenter/index.md
@@ -301,7 +301,7 @@ You may also want to enable Cost Anomaly Detection which is an AWS Cost Manageme
 
 ### Use the karpenter.sh/do-not-disrupt annotation to prevent Karpenter from deprovisioning a node
 
-If you are running a critical application on a Karpenter-provisioned node, such as a *long running* batch job or stateful application, *and* the node’s TTL has expired, the application will be interrupted when the instance is terminated. By adding a `karpenter.sh/karpenter.sh/do-not-disrupt` annotation to the pod, you are instructing Karpenter to preserve the node until the Pod is terminated or the `karpenter.sh/do-not-disrupt` annotation is removed. See [Distruption](https://karpenter.sh/docs/concepts/disruption/#node-level-controls) documentation for further information.
+If you are running a critical application on a Karpenter-provisioned node, such as a *long running* batch job or stateful application, *and* the node’s TTL has expired, the application will be interrupted when the instance is terminated. By adding a `karpenter.sh/do-not-disrupt` annotation to the pod, you are instructing Karpenter to preserve the node until the Pod is terminated or the `karpenter.sh/do-not-disrupt` annotation is removed. See [Distruption](https://karpenter.sh/docs/concepts/disruption/#node-level-controls) documentation for further information.
 
 If the only non-daemonset pods left on a node are those associated with jobs, Karpenter is able to target and terminate those nodes so long as the job status is succeed or failed.
 


### PR DESCRIPTION
*Description of changes:*

The annotation to prevent disruptions is `karpenter.sh/do-not-disrupt`. This can be found from here: https://karpenter.sh/docs/concepts/disruption/#pod-level-controls

(This fixes a typo)