### PR TITLE
Update iam.md

### DIFF
--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -193,7 +193,7 @@ By default when you provision an EKS cluster, the API cluster endpoint is set to
 
 ### Don't use a service account token for authentication
 
-A service account token is a long-lived, static credential. If it is compromised, lost, or stolen, an attacker may be able to perform all the actions associated with that token until the service account is deleted. At times, you may need to grant an exception for applications that have to consume the Kubernetes API from outside the cluster, e.g. a CI/CD pipeline application. If such applications run on AWS infrastructure, like EC2 instances, consider using an instance profile and mapping that to a Kubernetes RBAC role.
+A service account token is a long-lived, static credential. If it is compromised, lost, or stolen, an attacker may be able to perform all the actions associated with that token until the service account is deleted. At times, you may need to grant an exception for applications that have to consume the Kubernetes API from outside the cluster, e.g. a CI/CD pipeline application. If such applications run on AWS infrastructure, like EC2 instances, consider using an instance profile and mapping that to a Kubernetes RBAC role via Cluster Access Manager or the aws-auth ConfigMap (deprecated). 
 
 ### Employ least privileged access to AWS Resources
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Providing more clarity in the 'Don't use a service account token for authentication' section for the alternative approach of using instance profile and mapping to RBAC role can be done by using the Cluster Access Manager or the aws-auth ConfigMap (deprecated).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
