### PR TITLE
Scan all content for links to outdated OSS projects

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/linkbot
       with:
-        glob: "content/security/docs/*.md"
+        glob: "content/**/*.md"
         max_days_old: 730


### PR DESCRIPTION
This change will update the link-checking GH action to scan all content for links to unmaintained or archived OSS projects instead of only scanning security-related docs. Once merged, this will create new issues for the following (as of 8/8/24):

```
Check failed for https://github.com/hjacobs/kube-ops-view: CheckFailures.ARCHIVED
Check failed for https://github.com/mhausenblas/right-size-guide: CheckFailures.TOO_LONG_SINCE_PUSH: 2020-03-26
Check failed for https://github.com/hjacobs/kube-janitor: CheckFailures.ARCHIVED
Check failed for https://github.com/hjacobs/kube-resource-report: CheckFailures.ARCHIVED
Check failed for https://github.com/awslabs/k8s-cloudwatch-adapter/blob/master/samples/sqs/README.md: CheckFailures.ARCHIVED
Check failed for https://github.com/helm/charts/tree/master/stable/cluster-overprovisioner: CheckFailures.ARCHIVED
Check failed for https://github.com/awslabs/k8s-cloudwatch-adapter: CheckFailures.ARCHIVED
Check failed for https://github.com/hjacobs/kube-downscaler: CheckFailures.ARCHIVED
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
