### PR TITLE
Fix broken link to file that no longer exists in amazon-eks-ami repo

### DIFF
--- a/content/networking/vpc-cni/index.md
+++ b/content/networking/vpc-cni/index.md
@@ -79,7 +79,7 @@ Keep in mind that infrastructure pods, often running as daemon sets, each contri
 * Amazon Elastic LoadBalancer
 * Operational pods for metrics-server
 
-We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, see [eni-max-Pods.txt](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt) on GitHub.
+We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, you can generate `eni-max-Pods.txt` as described in the [awslabs/amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/development.md) repo on GitHub.
 
 ![illustration of multiple ENIs attached to a node](./image-5.png)
 


### PR DESCRIPTION
**Issue #, if available:**

n/a

**Description of changes:**

Remove a broken link to a file that no longer exists in another repo.

Instead, link to a Markdown page in that same repo which describes how to generate aforementioned file.

(This file is generated by a Make target in `amazon-vpc-cni-k8s` repo using:)
```
 make generate-limits
```

Feels less brittle linking to that page which describes the steps rather than duplicating the steps here (lest they become outdated again).


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
