### PR TITLE
Ignore references to old/unmaintained projects in closed issues

### DIFF
--- a/.github/actions/linkbot/linkbot/__main__.py
+++ b/.github/actions/linkbot/linkbot/__main__.py
@@ -13,7 +13,7 @@ conf = LinkBotConfig()
 gh = github.Client(conf.gh_token)
 repo_root = pathlib.Path(conf.repo_root)
 all_links = github_links_in_files(repo_root, conf.glob)
-bot_messages = gh.get_open_issue_messages(conf.repo_url, conf.gh_user)
+bot_messages = gh.get_all_issue_messages(conf.repo_url, conf.gh_user)
 existing_links = github_links_in_strs(bot_messages)
 for link in all_links:
     try:

--- a/.github/actions/linkbot/linkbot/github.py
+++ b/.github/actions/linkbot/linkbot/github.py
@@ -43,10 +43,10 @@ class Client:
         )
 
 
-    def get_open_issue_messages(self, repo_url, user):
+    def get_all_issue_messages(self, repo_url, user):
         full_name = repo_full_name_from_url(repo_url)
         repo = self._pygh.get_repo(full_name)
-        return [issue.body for issue in repo.get_issues(state='open', creator=user)]
+        return [issue.body for issue in repo.get_issues(state='all', creator=user)]
 
 
     def create_issue(self, repo_url, title, body):

--- a/.github/actions/linkbot/tests/test_github.py
+++ b/.github/actions/linkbot/tests/test_github.py
@@ -23,9 +23,7 @@ def test_get_repo_stats():
 
 
 @pytest.mark.network
-def test_get_open_issue_messages():
+def test_get_all_issue_messages():
     gh = Client(os.environ.get('LINKBOT_GH_TOKEN'))
-    expected = 'java.lang.IllegalArgumentException'
-    messages = gh.get_open_issue_messages('https://github.com/bellkev/dacom', 'r00k')
-    assert len(messages) == 1
-    assert expected in messages[0]
+    messages = gh.get_all_issue_messages('https://github.com/bellkev/dacom', 'r00k')
+    assert len(messages) == 2


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* This modifies the "linkbot" action that scans for references to old/unmaintained projects so that it ignores any issues that have already been surfaced in prior issues. The previous behavior was that any _open_ issues would not be recreated, but references in closed issues would be ignored.

In the future, it would probably be preferable to have a more robust allow-list for references to old projects that are considered acceptable. In the meantime, this behavior will allow maintainers to durably suppress warnings that are not of concern by simply closing issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
