### PR TITLE
Adding `block announce` for GitHub site deprecation

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,2 +1,5 @@
 {% extends "base.html" %}
 
+{% block announce %}
+<h2 style="color:#F2F2F2;text-align: center;"><b> Hi everyone! EKS Best Practices Guide has moved to <a style="color:#ff9900;text-decoration: underline" href="https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html">AWS Documentation.</a></u> This GitHub Pages site is deprecated. </b></h2>
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<h2 style="color:#F2F2F2;text-align: center;"><b> Hi everyone! EKS Best Practices Guide has moved to <a style="color:#ff9900;text-decoration: underline" href="https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html">AWS Documentation.</a></u> This GitHub Pages site is deprecated. </b></h2>
+<h2 style="color:#F2F2F2;text-align: center;"><b> Hi everyone! EKS Best Practices Guide has moved to <a style="color:#ff9900;text-decoration: underline" href="https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html">AWS Documentation</a></u>. This GitHub Pages site is deprecated. </b></h2>
 {% endblock %}


### PR DESCRIPTION
*Description of changes:*

Due the announcement of Best Practices Guide being moved to AWS Documentation, we're adding an announcement banner on the top of the page to inform the audience about the changes, and providing a link with the new home for the guide.

