### PR TITLE
fix: Deprecation announcement

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,6 @@ theme:
   features:
     - tabs
     - content.code.copy
-    - announce.dismiss
     - header.autohide
   palette:
     - scheme: default

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,2 +1,5 @@
 {% extends "base.html" %}
 
+{% block announce %}
+<h2 style="color:#F2F2F2;text-align: center;"><b> Hi everyone! EKS Best Practices Guide has moved to <a style="color:#ff9900;text-decoration: underline" href="https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html">AWS Documentation.</a></u> This GitHub Pages site is deprecated. </b></h2>
+{% endblock %}


### PR DESCRIPTION
*Description of changes:*

Removing the `announce.dismiss` option from `mkdocs.yml` to avoid audience closing and loosing the announcement banner.


