### PR TITLE
Provide CloudWatch query to help customer identify clients sending re…

### DIFF
--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -829,8 +829,20 @@ print("---")
 print("sqs response:")
 print(sqsresponse)
 ```
-
 If you're migrating an application from another AWS compute service, such as EC2, to EKS with IRSA, this is a particularly important detail. On other compute services initializing an AWS SDK session does not call AWS STS unless you instruct it to.
+
+
+### CloudWatch query to help users identify clients sending requests to global STS endpoint
+
+Run CloudWatch query below to get ste endpoint. Run this If stsendpoint equals to "sts.amazonaws.com", then it is a global STS endpoint.
+
+```aidl
+fields @timestamp, @message, @logStream, @log,stsendpoint
+| filter @logStream like /authenticator/
+| filter @message like /stsendpoint/
+| sort @timestamp desc
+| limit 10000
+```
 
 ### Alternative approaches
 

--- a/content/security/docs/iam.md
+++ b/content/security/docs/iam.md
@@ -834,7 +834,7 @@ If you're migrating an application from another AWS compute service, such as EC2
 
 ### CloudWatch query to help users identify clients sending requests to global STS endpoint
 
-Run CloudWatch query below to get ste endpoint. Run this If stsendpoint equals to "sts.amazonaws.com", then it is a global STS endpoint.
+Run CloudWatch query below to get sts endpoint. Run this If stsendpoint equals to "sts.amazonaws.com", then it is a global STS endpoint.
 
 ```aidl
 fields @timestamp, @message, @logStream, @log,stsendpoint


### PR DESCRIPTION
Provide CloudWatch query to help customer identify clients sending requests to global STS endpoint

*Issue #, if available:*

*Description of changes:*

Test on beta CO accounts. Got STS endpoint from authenticator logs:

time="2024-11-30T12:06:40Z" level=info msg="STS response" accesskeyid=ASIAABCDEFGGH accountid=123456789012 arn="arn:aws:sts::123456789012:assumed-role/AWSWesleyClusterManagerLambda-Add-AddonManagerRole-JOPQTE96H0BA/EKSClusterInsightsAuth" client="127.0.0.1:55380" method=POST path=/authenticate session=EKSClusterInsightsAuth stsendpoint=sts.us-west-2.amazonaws.com userid=AROACSJHFKKHJAHSJX

checkeded with global STS endpoint:

time="2024-12-06T11:46:59Z" level=info msg="STS response" accesskeyid=ASIAABCDEFGGH accountid=123456789012 arn="arn:aws:sts::123456789012:assumed-role/AmazonEKSClusterInsightsViewOnlyRole/EKSClusterInsightsAuth" client="127.0.0.1:60480" method=POST path=/authenticate session=EKSClusterInsightsAuth stsendpoint=sts.amazonaws.com userid=AROACSJHFKKHJAHSJX





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
