### PR TITLE
Update karpenter.adoc

### DIFF
--- a/latest/bpg/autoscaling/karpenter.adoc
+++ b/latest/bpg/autoscaling/karpenter.adoc
@@ -71,7 +71,7 @@ The following best practices cover topics related to Karpenter itself.
 
 === Lock down AMIs in production clusters
 
-We strongly recommend that you pin well-known AMIs used by Karpenter for production clusters.
+We strongly recommend that you pin well-known Amazon Machine Images (AMIs) used by Karpenter for production clusters.
 Using `amiSelector` with an alias set to `@latest`, or using some other method that results in deploying untested AMIs as they are released, offers the risk of workload failures and downtime in your production clusters. As a result, we strongly recommend pinning tested working versions of AMIs for your production clusters while you test newer versions in non-production clusters. For example, you could set an alias in your NodeClass as follows:
 
 amiSelectorTerms

--- a/latest/bpg/autoscaling/karpenter.adoc
+++ b/latest/bpg/autoscaling/karpenter.adoc
@@ -69,6 +69,16 @@ and pod scheduling.
 
 The following best practices cover topics related to Karpenter itself.
 
+=== Lock down AMIs in production clusters
+
+We strongly recommend that you pin well-known AMIs used by Karpenter for production clusters.
+Using `amiSelector` with an alias set to `@latest`, or using some other method that results in deploying untested AMIs as they are released, offers the risk of workload failures and downtime in your production clusters. As a result, we strongly recommend pinning tested working versions of AMIs for your production clusters while you test newer versions in non-production clusters. For example, you could set an alias in your NodeClass as follows:
+
+amiSelectorTerms
+  - alias: al2023@v20240807
+
+For information on managing and pinning down AMIs in Karpenter, see https://karpenter.sh/docs/tasks/managing-amis/[Managing AMIs] in the Karpenter documentation.
+
 === Use Karpenter for workloads with changing capacity needs
 
 Karpenter brings scaling management closer to Kubernetes native APIs

--- a/latest/bpg/autoscaling/karpenter.adoc
+++ b/latest/bpg/autoscaling/karpenter.adoc
@@ -74,8 +74,11 @@ The following best practices cover topics related to Karpenter itself.
 We strongly recommend that you pin well-known Amazon Machine Images (AMIs) used by Karpenter for production clusters.
 Using `amiSelector` with an alias set to `@latest`, or using some other method that results in deploying untested AMIs as they are released, offers the risk of workload failures and downtime in your production clusters. As a result, we strongly recommend pinning tested working versions of AMIs for your production clusters while you test newer versions in non-production clusters. For example, you could set an alias in your NodeClass as follows:
 
+[source,yaml]
+----
 amiSelectorTerms
   - alias: al2023@v20240807
+----
 
 For information on managing and pinning down AMIs in Karpenter, see https://karpenter.sh/docs/tasks/managing-amis/[Managing AMIs] in the Karpenter documentation.
 


### PR DESCRIPTION
Added a best practice for locking down AMIs in production clusters.

*Description of changes:* Strongly recommended that customers pin AMIs for production clusters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
