### PR TITLE
Replacing the hyperlink of Karpenter Blueprints to https://github.com…

### DIFF
--- a/latest/bpg/autoscaling/karpenter.adoc
+++ b/latest/bpg/autoscaling/karpenter.adoc
@@ -615,7 +615,7 @@ is not yet ready or has been terminated.
 As Karpenter takes an application-first approach to provision compute
 capacity for to the Kubernetes data plane, there are common workload
 scenarios that you might be wondering how to configure them properly.
-https://github.com/aws-samples/karpenter-blueprints[Karpenter
+https://github.com/aws-ia/terraform-aws-eks-blueprints-addons[Karpenter
 Blueprints] is a repository that includes a list of common workload
 scenarios following the best practices described here. You’ll have all
 the resources you need to even create an EKS cluster with Karpenter


### PR DESCRIPTION
…/aws-ia/terraform-aws-eks-blueprints-addons

As discussed here: https://gist.github.com/brunobritodev/4760783ef8a5f99bfdceaf3e545f920c

  -  EKS Best Practices: Was pointing to a repository using EKS version 1.30 and a Karpenter module that does not support POD Identity Association.
  -  Karpenter.sh: Recommends a more updated repository that uses a Karpenter module compatible with all the latest EKS features.

Therefore, updating the hyperlink to refer the recommendations from Karpenter.sh

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
