### PR TITLE
Add section for how to prevent DaemonSet thundering herd issues

### DIFF
--- a/latest/bpg/scalability/control-plane.adoc
+++ b/latest/bpg/scalability/control-plane.adoc
@@ -313,4 +313,127 @@ If you call the API without any arguments it will be the most resource intensive
 /api/v1/pods
 ----
 
+=== Prevent DaemonSet thundering herds
+
+A DaemonSet ensures that all (or some) nodes run a copy of a pod. As nodes join the cluster, the daemonset-controller creates pods for those nodes. As nodes leave the cluster, those pods are garbage collected. Deleting a DaemonSet will clean up the pods it created.
+
+Some typical uses of a DaemonSet are:
+
+* Running a cluster storage daemon on every node
+* Running a logs collection daemon on every node
+* Running a node monitoring daemon on every node
+
+On clusters with thousands of nodes, creating a new DaemonSet, updating a DaemonSet, or increasing the number of nodes can result in a high load placed on the control plane. If DaemonSet pods issue expensive API server requests on pod start-up, they can cause high resource use on the control plane from a large number of concurrent requests. 
+
+In normal operation, you can use a `RollingUpdate` to ensure a gradual rollout of new DaemonSet pods. With a `RollingUpdate` update strategy, after you update a DaemonSet template, the controller kills old DaemonSet pods and creates new DaemonSet pods automatically in a controlled fashion. At most one pod of the DaemonSet will be running on each node during the whole update process. You can perform a gradual rollout by setting `maxUnavailable` to 1, `maxSurge` to 0, and `minReadySeconds` to 60. If you do not specify an update strategy, Kubernetes will default to a creating a `RollingUpdate` with `maxUnavailable` as 1, `maxSurge` as 0, and `minReadySeconds` as 0.
+```
+minReadySeconds: 60
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
+```
+
+A `RollingUpdate` ensures the gradual rollout of new DaemonSet pods if the DaemonSet is already created and has the expected number of `Ready` pods across all nodes. Thundering herd issues can result under certain conditions that are not covered by `RollingUpdate` strategies.
+
+==== Prevent thundering herds on DaemonSet creation
+
+By default, regardless of the `RollingUpdate` configuration, the daemonset-controller in the kube-controller-manager will create pods for all matching nodes simultaneously when you create a new DaemonSet. To force a gradual rollout of pods after you create a DaemonSet, you can use either a `NodeSelector` or `NodeAffinity`. This will create a DaemonSet that matches zero nodes and then you can gradually update nodes to make them eligible for running a pod from the DaemonSet at a controlled rate. You can follow this approach:
+
+* Add a label to all nodes for `run-daemonset=false`.
+```
+kubectl label nodes --all run-daemonset=false
+```
+* Create your DaemonSet with a `NodeAffinity` setting to match any node without a `run-daemonset=false` label. Initially, this will result in your DaemonSet having no corresponding pods.
+```
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: run-daemonset
+          operator: NotIn
+          values:
+          - "false"
+```
+* Remove the `run-daemonset=false` label from your nodes at a controlled rate. You can use this bash script as an example:
+```
+#!/bin/bash
+
+nodes=$(kubectl get --raw "/api/v1/nodes" | jq -r '.items | .[].metadata.name')
+
+for node in ${nodes[@]}; do
+   echo "Removing run-daemonset label from node $node"
+   kubectl label nodes $node run-daemonset- 
+   sleep 5
+done
+```
+* Optionally, remove the `NodeAffinity` setting from your DaemonSet object. Note that this will also trigger a `RollingUpdate` and gradually replace all existing DaemonSet pods because the DaemonSet template changed.
+
+==== Prevent thundering herds on node scale-outs
+
+Similarly to DaemonSet creation, creating new nodes at a fast rate can result in a large number of DaemonSet pods starting concurrently. You should create new nodes at a controlled rate so that the controller creates DaemonSet pods at this same rate. If this is not possible, you can make the new nodes initially ineligible for the existing DaemonSet by using `NodeAffinity`. Next, you can add a label to the new nodes gradually so that the daemonset-controller creates pods at a controlled rate. You can follow this approach:
+
+* Add a label to all existing nodes for `run-daemonset=true`
+```
+kubectl label nodes --all run-daemonset=true
+```
+* Update your DaemonSet with a `NodeAffinity` setting to match any node with a `run-daemonset=true` label. Note that this will also trigger a `RollingUpdate` and gradually replace all existing DaemonSet pods because the DaemonSet template changed. You should wait for the `RollingUpdate` to complete before advancing to the next step.
+```
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: run-daemonset
+          operator: In
+          values:
+          - "true"
+```
+* Create new nodes in your cluster. Note that these nodes will not have the `run-daemonset=true` label so the DaemonSet will not match those nodes.
+* Add the `run-daemonset=true` label to your new nodes (which currently do not have the `run-daemonset` label) at a controlled rate. You can use this bash script as an example:
+```
+#!/bin/bash
+
+nodes=$(kubectl get --raw "/api/v1/nodes?labelSelector=%21run-daemonset" | jq -r '.items | .[].metadata.name')
+
+for node in ${nodes[@]}; do
+   echo "Adding run-daemonset=true label to node $node"
+   kubectl label nodes $node run-daemonset=true
+   sleep 5
+done
+```
+* Optionally, remove the `NodeAffinity` setting from your DaemonSet object and remove the `run-daemonset` label from all nodes.
+
+==== Prevent thundering herds on DaemonSet updates
+
+A `RollingUpdate` policy will only respect the `maxUnavailable` setting for DaemonSet pods that are `Ready`. If a DaemonSet has only `NotReady` pods or a large percentage of `NotReady` pods and you update its template, the daemonset-controller will create new pods concurrently for any `NotReady` pods. This can result in thundering herd issues if there are a significant number of `NotReady` pods, for example if pods are continually crash looping or are failing to pull images. 
+
+To force a gradual rollout of pods when you update a DaemonSet and there are `NotReady` pods, you can temporarily change the update strategy on the DaemonSet from `RollingUpdate` to `OnDelete`. With `OnDelete`, after you update a DaemonSet template, the controller creates new pods after you manually delete the old ones so you can control the rollout of new pods. You can follow this approach:
+
+* Check if you have any `NotReady` pods in your DaemonSet. 
+* If no, you can safely update the DaemonSet template and the `RollingUpdate` strategy will ensure a gradual rollout.
+* If yes, you should first update your DaemonSet to use the `OnDelete` strategy. 
+```
+updateStrategy:
+  type: OnDelete
+```
+* Next, update your DaemonSet template with the needed changes.
+* After this update, you can delete the old DaemonSet pods by issuing delete pod requests at a controlled rate. You can use this bash script as an example where the DaemonSet name is fluentd-elasticsearch in the kube-system namespace:
+```
+#!/bin/bash
+
+daemonset_pods=$(kubectl get --raw "/api/v1/namespaces/kube-system/pods?labelSelector=name%3Dfluentd-elasticsearch" | jq -r '.items | .[].metadata.name')
+
+for pod in ${daemonset_pods[@]}; do
+   echo "Deleting pod $pod"
+   kubectl delete pod $pod -n kube-system
+   sleep 5
+done
+```
+* Finally, you can update your DaemonSet back to the earlier `RollingUpdate` strategy.
+
+
+
 


### PR DESCRIPTION
*Description of changes:*
The EKS scalability team has observed resource exhaustion occur on clusters with large node counts due to thundering-herd issues where a large number of pods from DaemonSets issue expensive list requests concurrently. DaemonSets are typically configured with a RollingUpdate strategy to ensure a gradual rollout of new pods, however, there are 3 cases that are not covered currently:

- New DaemonSet creation
- Node scale-outs
- Updating a DaemonSet template when there are NotReady pods


*Testing:*
Example DaemonSet object used in the following tests:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluentd-elasticsearch
  namespace: kube-system
  labels:
    k8s-app: fluentd-logging
spec:
  selector:
    matchLabels:
      name: fluentd-elasticsearch
  minReadySeconds: 60
  updateStrategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      labels:
        name: fluentd-elasticsearch
    spec:
      containers:
      - name: fluentd-elasticsearch
        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
```

1. Showing that there's a thundering herd issue on creation of a new DaemonSet:
```
% kubectl create -f /tmp/daemonset.yaml
daemonset.apps/fluentd-elasticsearch created

% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS    RESTARTS   AGE
fluentd-elasticsearch-29lsh   1/1     Running   0          68s
fluentd-elasticsearch-2bscp   1/1     Running   0          68s
fluentd-elasticsearch-2twqs   1/1     Running   0          68s
...
```

2. Showing that there's a thundering herd issue when a node scale out occurs with an existing DaemonSet:
```
# Cluster is scaled out from 100 -> 150 nodes
% kubectl get pods -n kube-system -l name=fluentd-elasticsearch | grep -v m
NAME                          READY   STATUS    RESTARTS   AGE
fluentd-elasticsearch-2zwsc   1/1     Running   0          41s
fluentd-elasticsearch-5594r   1/1     Running   0          43s
fluentd-elasticsearch-567z7   1/1     Running   0          43s
...
```

3. Showing that there's a thundering herd issue on an update to an existing DaemonSet if there are a large number of NotReady pods:
```
% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS         RESTARTS   AGE
fluentd-elasticsearch-2cjdw   0/1     ErrImagePull   0          7s
fluentd-elasticsearch-2l8wv   0/1     ErrImagePull   0          6s
fluentd-elasticsearch-2qvn9   0/1     ErrImagePull   0          8s
...

# after fixing image URL
% kubectl edit daemonset fluentd-elasticsearch -n kube-system
% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS    RESTARTS   AGE
fluentd-elasticsearch-2t2zf   1/1     Running   0          5s
fluentd-elasticsearch-2tj4b   1/1     Running   0          4s
fluentd-elasticsearch-424s2   1/1     Running   0          9s
...
```

4.  To fix the thundering herd issue on new DaemonSet creation:
```
% kubectl label nodes --all run-daemonset=false

node/ip-192-168-105-20.us-west-2.compute.internal labeled
node/ip-192-168-107-101.us-west-2.compute.internal labeled
node/ip-192-168-109-29.us-west-2.compute.internal labeled
...

# create same DaemonSet with the NodeAffinity setting provided
% kubectl create -f /tmp/daemonset.yaml
daemonset.apps/fluentd-elasticsearch created

% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
No resources found in kube-system namespace.

# Now, run bash script to remove the node labels and gradually create pods
% /tmp/remove_labels.sh
Removing run-daemonset label from node ip-192-168-105-20.us-west-2.compute.internal
node/ip-192-168-105-20.us-west-2.compute.internal unlabeled
Removing run-daemonset label from node ip-192-168-107-101.us-west-2.compute.internal
node/ip-192-168-107-101.us-west-2.compute.internal unlabeled
Removing run-daemonset label from node ip-192-168-109-29.us-west-2.compute.internal
node/ip-192-168-109-29.us-west-2.compute.internal unlabeled
...

# pods are being created 5s apart
% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS    RESTARTS   AGE
fluentd-elasticsearch-69lt5   1/1     Running   0          5s
fluentd-elasticsearch-gb9qb   1/1     Running   0          52s
fluentd-elasticsearch-gm5qz   1/1     Running   0          17s
fluentd-elasticsearch-gmvfl   1/1     Running   0          40s
```

5. To fix thundering herd issue on node scale-outs with an existing DaemonSet:
```
% kubectl label nodes --all run-daemonset=true
node/ip-192-168-103-141.us-west-2.compute.internal labeled
node/ip-192-168-103-150.us-west-2.compute.internal labeled
node/ip-192-168-105-20.us-west-2.compute.internal labeled

# Add the nodeAffinity setting to match any nodes with the run-daemonset=true label
% kubectl edit daemonset fluentd-elasticsearch -n kube-system

# Complete the node scale-out. Next, run the bash script to add the run-daemonset=true to the new nodes
% /tmp/add_labels.sh
Adding run-daemonset=true label to node ip-192-168-102-154.us-west-2.compute.internal
node/ip-192-168-102-154.us-west-2.compute.internal labeled
Adding run-daemonset=true label to node ip-192-168-109-118.us-west-2.compute.internal
node/ip-192-168-109-118.us-west-2.compute.internal labeled
Adding run-daemonset=true label to node ip-192-168-110-239.us-west-2.compute.internal
...

%  kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS              RESTARTS   AGE
fluentd-elasticsearch-2qwhf   1/1     Running             0          76s
fluentd-elasticsearch-5pzsr   1/1     Running             0          2m20s
fluentd-elasticsearch-5s7jd   0/1     ContainerCreating   0          0s
...
```

6.  To fix thundering herd issue on DaemonSet updates where there are a large number of NotReady pods:
```
% kubectl create -f /tmp/daemonset.yaml
daemonset.apps/fluentd-elasticsearch created

% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS         RESTARTS   AGE
fluentd-elasticsearch-24qlz   0/1     ErrImagePull   0          10s
fluentd-elasticsearch-2hxlp   0/1     ErrImagePull   0          8s
fluentd-elasticsearch-2nrzh   0/1     ErrImagePull   0          10s
...

# Change the UpdateStrategy to OnDelete and fix the image URL for the pod
% kubectl edit daemonset fluentd-elasticsearch -n kube-system

# Now, run bash script to delete the existing NotReady pods and new pods will be gradually created
# by the daemonset-controller
% /tmp/delete_pods.sh
Removing deleting pod fluentd-elasticsearch-24qlz
pod "fluentd-elasticsearch-24qlz" deleted
Removing deleting pod fluentd-elasticsearch-2hxlp
pod "fluentd-elasticsearch-2hxlp" deleted
Removing deleting pod fluentd-elasticsearch-2nrzh
pod "fluentd-elasticsearch-2nrzh" deleted
...

% kubectl get pods -n kube-system -l name=fluentd-elasticsearch
NAME                          READY   STATUS             RESTARTS   AGE
fluentd-elasticsearch-5mz9f   1/1     Running            0          2s
fluentd-elasticsearch-5x5f4   0/1     ImagePullBackOff   0          5m29s
fluentd-elasticsearch-675sj   0/1     ImagePullBackOff   0          5m31s
fluentd-elasticsearch-67gsp   0/1     ImagePullBackOff   0          5m29s
fluentd-elasticsearch-68zzq   1/1     Running            0          16s
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
