### PR TITLE
docs: Remove recommendation to maintain ipv4 connectivity to EKS API

### DIFF
--- a/latest/bpg/networking/ipv6.adoc
+++ b/latest/bpg/networking/ipv6.adoc
@@ -89,10 +89,6 @@ image::ipv6_image-5.png[illustration of cluster including X-ENIs]
 
 == Recommendations
 
-=== Maintain Access to IPv4 EKS APIs
-
-EKS APIs are accessible by IPv4 only. This also includes the Cluster API Endpoint. You will not be able to access cluster endpoints and APIs from an IPv6 only network. It is required that your network supports (1) an IPv6 transition mechanism such as NAT64/DNS64 that facilitates communication between IPv6 and IPv4 hosts and (2) a DNS service that supports translations of IPv4 endpoints.
-
 === Schedule Based on Compute Resources
 
 A single IPv6 prefix is sufficient to run many Pods on a single node. This also effectively removes ENI and IP limitations on the maximum number of Pods on a node. Although IPv6 removes direct dependency on max-Pods, when using prefix attachments with smaller instance types like the m5.large, you're likely to exhaust the instance's CPU and memory resources long before you exhaust its IP addresses. You must set the EKS recommended maximum Pod value by hand if you are using self-managed node groups or a managed node group with a custom AMI ID.


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
EKS API has had ipv6 support since [Oct 2024](https://aws.amazon.com/about-aws/whats-new/2024/10/amazon-eks-endpoints-connectivity-ipv6/). Also see https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
