### PR TITLE
Update vpc-cni.adoc

### DIFF
--- a/latest/bpg/networking/vpc-cni.adoc
+++ b/latest/bpg/networking/vpc-cni.adoc
@@ -94,7 +94,7 @@ Keep in mind that infrastructure pods, often running as daemon sets, each contri
 * Amazon Elastic LoadBalancer
 * Operational pods for metrics-server
 
-We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, see https://github.com/awslabs/amazon-eks-ami/blob/b8db09326bbb215ba7407c25df4403e1de0824d4/nodeadm/internal/kubelet/eni-max-pods.txt#L4[eni-max-Pods.txt] on GitHub.
+We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, see https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni-max-pods.txt[eni-max-Pods.txt] on GitHub.
 
 image::cni_image-5.png[illustration of multiple ENIs attached to a node]
 

--- a/latest/bpg/networking/vpc-cni.adoc
+++ b/latest/bpg/networking/vpc-cni.adoc
@@ -94,7 +94,7 @@ Keep in mind that infrastructure pods, often running as daemon sets, each contri
 * Amazon Elastic LoadBalancer
 * Operational pods for metrics-server
 
-We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, see https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt[eni-max-Pods.txt] on GitHub.
+We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, see https://github.com/awslabs/amazon-eks-ami/blob/b8db09326bbb215ba7407c25df4403e1de0824d4/nodeadm/internal/kubelet/eni-max-pods.txt#L4[eni-max-Pods.txt] on GitHub.
 
 image::cni_image-5.png[illustration of multiple ENIs attached to a node]
 


### PR DESCRIPTION
Link provided for eni-max-pods.txt doesn't work and results in page not found as there is no branch named as "master". 
Previous URL: https://github.com/awslabs/amazon-eks-ami/blob/main/files/eni-max-pods.txt

I have instead added the correct URL corresponding to the required file.
Updated URL: https://github.com/awslabs/amazon-eks-ami/blob/b8db09326bbb215ba7407c25df4403e1de0824d4/nodeadm/internal/kubelet/eni-max-pods.txt#L4

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
