### PR TITLE
updating the jsonpath for fetching SG associated with fargate pods. 

### DIFF
--- a/latest/bpg/networking/sgpp.adoc
+++ b/latest/bpg/networking/sgpp.adoc
@@ -153,7 +153,7 @@ You can use the below commands to find the security groups applied to a Fargate 
 
 [,bash]
 ----
-kubectl get pod FARGATE_POD -o jsonpath='{.metadata.annotations.vpc\.amazonaws\.com/pod-eni}{"\n"}'
+kubectl get pod FARGATE_POD -o jsonpath='{.metadata.annotations.fargate\.amazonaws\.com/pod-sg}{"\n"}'
 ----
 
 Note down the eniId from above command.


### PR DESCRIPTION
*Issue #, if available:* Its regarding the below command :

```
kubectl get pod FARGATE_POD -o jsonpath='{.metadata.annotations.vpc\.amazonaws\.com/pod-eni}{"\n"}'
```

The aforementioned jsonpath no longer return the expected output.

*Description of changes:*

changing the jsonpath to `'{.metadata.annotations.fargate\.amazonaws\.com/pod-sg}{"\n"}'`

example :

```
❯ kubectl get pod -n test simple-nginx-pod -o jsonpath='{.metadata.annotations.vpc\.amazonaws\.com/pod-eni}{"\n"}'

❯ kubectl get pod -n test simple-nginx-pod -o jsonpath='{.metadata.annotations.fargate\.amazonaws\.com/pod-sg}{"\n"}'
sg-0[redacted]4

❯ kubectl get pod -n test simple-nginx-pod -ojsonpath='{.metadata.annotations}' | jq .
{
  "CapacityProvisioned": "0.25vCPU 0.5GB",
  "Logging": "LoggingDisabled: LOGGING_CONFIGMAP_NOT_FOUND",
  "fargate.amazonaws.com/pod-sg": "sg-0[redacted]4",
  "kubectl.kubernetes.io/last-applied-configuration": redacted
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
