### PR TITLE
Update incidents.adoc

### DIFF
--- a/latest/bpg/security/incidents.adoc
+++ b/latest/bpg/security/incidents.adoc
@@ -169,11 +169,9 @@ container.
 * *Run commands to save container-level state before evidence is
 altered*. You can use capabilities of the container runtime to capture
 information about currently running containers. For example, with
-Docker, you could do the following:
-** `docker top CONTAINER` for processes running.
-** `docker logs CONTAINER` for daemon level held logs.
-** `docker inspect CONTAINER` for various information about the
-container.
+Containerd, you could do the following:
+** `crictl ps` for processes running.
+** `crictl logs CONTAINER` for daemon level held logs.
 +
 The same could be achieved with containerd using the
 https://github.com/containerd/nerdctl[nerdctl] CLI, in place of


### PR DESCRIPTION
*Issue #, if available:*
Docker commands are shared on the Example-Section

*Description of changes:*
As Docker has been deprecated from EKS. There's no point of sharing examples of Docker Command. Thereby, changed to Containerd Commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
