### PR TITLE
Updating Incorrect kubeAPIQPS & Burst value.

### DIFF
--- a/latest/bpg/scalability/kcp_monitoring.adoc
+++ b/latest/bpg/scalability/kcp_monitoring.adoc
@@ -183,8 +183,8 @@ Kube Controller Manager, like all other controllers, has limits on how many oper
     concurrentServiceSyncs: 5
     concurrentResourceQuotaSyncs: 5
     concurrentGcSyncs: 20
-    kubeAPIBurst: 20
-    kubeAPIQPS: "30"
+    kubeAPIBurst: 30
+    kubeAPIQPS: "20"
 ----
 
 These controllers have queues that fill up during times of high churn on a cluster. In this case we see the replicaset set controller has a large backlog in its queue.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The value provided for kubeAPIQPS and kubeAPIBurst are incorrect. Please review this documentation: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/

--kube-api-qps float     Default: 20
--kube-api-burst int32     Default: 30


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
