### PR TITLE
Update karpenter.adoc - fixed erroneous markdown link

### DIFF
--- a/latest/bpg/autoscaling/karpenter.adoc
+++ b/latest/bpg/autoscaling/karpenter.adoc
@@ -113,7 +113,8 @@ yet part of Karpenter.
 
 === Run the Karpenter controller on EKS Fargate or on a worker node that belongs to a node group
 
-Karpenter is installed using a [Helm chart](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#4-install-karpenter). 
+Karpenter is installed using a 
+https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#4-install-karpenter[Helm chart]. 
 The Helm chart installs the Karpenter controller and a webhook pod as a Deployment 
 that needs to run before the controller can be used for scaling your cluster.
 We recommend a minimum of one small node group with at least one worker


### PR DESCRIPTION
*Issue #, if available:* N/A
<img width="1047" height="167" alt="image" src="https://github.com/user-attachments/assets/10e4d1fd-c6ba-4664-94c1-0409abecaed7" />


*Description of changes:*
 Fixed erroneous Markdown link


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
