### PR TITLE
Remove old ETCD Metrics name and query

### DIFF
--- a/latest/bpg/reliability/controlplane.adoc
+++ b/latest/bpg/reliability/controlplane.adoc
@@ -142,8 +142,7 @@ status code, method, and host.
 |`etcd_request_duration_seconds` |Etcd request latency in seconds for
 each operation and object type.
 
-|`etcd_db_total_size_in_bytes` or
-`apiserver_storage_db_total_size_in_bytes` (starting with EKS v1.26)
+|`apiserver_storage_db_total_size_in_bytes`
 or `apiserver_storage_size_bytes` (starting with EKS v1.28) |Etcd
 database size.
 |===
@@ -152,11 +151,6 @@ Consider using the
 https://grafana.com/grafana/dashboards/14623[Kubernetes Monitoring
 Overview Dashboard] to visualize and monitor Kubernetes API server
 requests and latency and etcd latency metrics.
-
-The following Prometheus query can be used to monitor the current size
-of etcd. The query assumes there is job called `kube-apiserver` for
-scraping metrics from API metrics endpoint and the EKS version is below
-v1.26.
 
 [source,text]
 ----

--- a/latest/bpg/reliability/controlplane.adoc
+++ b/latest/bpg/reliability/controlplane.adoc
@@ -152,10 +152,6 @@ https://grafana.com/grafana/dashboards/14623[Kubernetes Monitoring
 Overview Dashboard] to visualize and monitor Kubernetes API server
 requests and latency and etcd latency metrics.
 
-[source,text]
-----
-max(etcd_db_total_size_in_bytes{job="kube-apiserver"} / (8 * 1024 * 1024 * 1024))
-----
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The metric `etcd_db_total_size_in_bytes` is not available after version 1.26 of kubernetes. Because of that, I removed references to it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
