### PR TITLE
Update monitoring guidance to utilize Prometheus Node Exporter

### DIFF
--- a/latest/bpg/networking/monitoring.adoc
+++ b/latest/bpg/networking/monitoring.adoc
@@ -62,7 +62,7 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 
 helm upgrade -i prometheus-node-exporter prometheus-community/prometheus-node-exporter \
   --set extraArgs[0]="--collector.ethtool" \
-  --set extraArgs[1]="--collector.ethtool.device-include=^eth.*" \
+  --set extraArgs[1]="--collector.ethtool.device-include=(eth|em|eno|ens|enp)[0-9s]+" \
   --set extraArgs[2]="--collector.ethtool.metrics-include=.*" \
   --set podAnnotations."prometheus\.io/scrape='true'" \
   --set podAnnotations."prometheus\.io/port='9100'"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replaces the python script from the archived repository [Showmax/prometheus-ethtool-exporter](https://github.com/Showmax/prometheus-ethtool-exporter) with the Prometheus [node_exporter](https://github.com/prometheus/node_exporter). This project is the industry standard and is actively maintained.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
