### PR TITLE
Update cluster-autoscaler.adoc; max-empty-bulk-delete is deprecated, document max-scale-down-parallelism instead

### DIFF
--- a/latest/bpg/autoscaling/cluster-autoscaler.adoc
+++ b/latest/bpg/autoscaling/cluster-autoscaler.adoc
@@ -565,8 +565,7 @@ https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#w
 |scan-interval |How often cluster is reevaluated for scale up or down
 |10 seconds
 
-|max-empty-bulk-delete |Maximum number of empty nodes that can be
-deleted at the same time. |10
+|max-scale-down-parallelism |Maximum number of nodes (both empty and needing drain) that can be deleted in parallel. |10
 
 |scale-down-delay-after-add |How long after scale up that scale down
 evaluation resumes |10 minutes


### PR DESCRIPTION
Update cluster-autoscaler.adoc; max-empty-bulk-delete is deprecated, document max-scale-down-parallelism instead

*Issue #, if available:*

*Description of changes:*
Remove max-empty-bulk-delete from "Additional Parameters". Replace with "max-scale-down-parallelism".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
