### PR TITLE
Added callout for DNS64 with EKS IPv6 support

### DIFF
--- a/latest/bpg/networking/ipv6.adoc
+++ b/latest/bpg/networking/ipv6.adoc
@@ -60,6 +60,8 @@ image::ipv6_eks-ipv4-snat-cni.png[EKS/IPv6, IPv4 egress-only flow]
 
 In the above diagram Pods will perform a DNS lookup for the endpoint and, upon receiving an IPv4 "`A`" response, Pod's node-only unique IPv4 address is translated through source network address translation (SNAT) to the Private IPv4 (VPC) address of the primary network interface attached to the EC2 Worker-node.
 
+NOTE: The above pattern requires DNS64 being disabled on subnets where EKS/IPv6 Pods are running. When DNS64 is enabled, the DNS resolver returns a synthesized IPv6 address for IPv4-only endpoints along with an IPv4 address. As a result, traffic routes through the NAT Gateway's (if included in the architecture) NAT64 functionality instead of staying within the VPC as shown in the pattern above. This may lead to unexpected NAT Gateway usage and associated costs.
+
 EKS/IPv6 Pods will also need to connect to IPv4 endpoints over the internet using public IPv4 Addresses, to achieve that a similar flow exists.
 The following diagram depict the flow of an IPv6 Pod connecting to an IPv4 endpoint outside the cluster boundary (internet routable):
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change calls out that DNS64 should be disabled on the subnets in order to get the desired behavior depicted in the *Pod to an external IPv4 endpoint* pattern . DNS64 is only needed on the subnets if you are running IPv6 only workloads in the subnet that need to communicate to IPv4 endpoints. Since the CNI plugin is installed (and recommended) on the EKS cluster, the pods have both an IPv4 and IPv6 address. Thus, when DNS64 is enabled on the subnet and a pod is looking to communicate with an only IPv4 endpoint (like a DynamoDB Gateway endpoint) a synthesized IPv6 address is returning thus causing the pod to use the IPv6 address (since it prefers it) which then causes the traffic to go to the NAT Gateway to do the NAT64 translation. This flow through the NAT Gateway, while it works, will unnecessarily drive up NAT Gateway usage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
