### PR TITLE
Fix Pod label, Nodegroup and nvidia chart name issue

### DIFF
--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -490,12 +490,12 @@ metadata:
   version: '1.33'
 
 managedNodeGroups:
-  - name: base-nodes
-    amiFamily: AmazonLinux2023
-    instanceType: m5.xlarge
-    desiredCapacity: 1
-    minSize: 1
-    maxSize: 2
+- name: base-nodes
+  amiFamily: AmazonLinux2023
+  instanceType: m5.xlarge
+  desiredCapacity: 1
+  minSize: 1
+  maxSize: 2
 
 - name: gpu-dra-nodes
   amiFamily: AmazonLinux2023

--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -526,7 +526,7 @@ eksctl create cluster -f dra-eks-cluster.yaml
 
 When you create a cluster using eksctl, the device plugin service is automatically installed in the kube-system namespace.
 
-. Verify that the NVIDIA device plugin service are available:
+Verify that the NVIDIA device plugin service are available:
 +
 [source,bash,subs="verbatim,attributes"]
 ----

--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -526,16 +526,14 @@ eksctl create cluster -f dra-eks-cluster.yaml
 
 When you create a cluster using eksctl, the device plugin service is automatically installed in the kube-system namespace.
 
-Verify that the NVIDIA device plugin service are available:
-+
-[source,bash,subs="verbatim,attributes"]
+Verify that the NVIDIA device plugin service is available:
+[,bash]
 ----
 kubectl get po -n kube-system | grep nvidia-device-plugin-daemonset
 ----
-+
+
 The following is the expected output:
-+
-[source,bash,subs="verbatim,attributes",role="nocopy"]
+[,bash]
 ----
 kube-system   nvidia-device-plugin-daemonset-2s6pv   1/1     Running   0          7m8s
 kube-system   nvidia-device-plugin-daemonset-8zhq8   1/1     Running   0          7m8s

--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -795,7 +795,7 @@ spec:
   - name: gpu0
     resourceClaimTemplateName: single-gpu
   nodeSelector:
-    NodeGroupType: gpu-dra      
+    node-type: "gpu-dra"
     nvidia.com/gpu.present: "true"
   tolerations:
   - key: "nvidia.com/gpu"
@@ -977,7 +977,7 @@ spec:
   - name: shared-gpu-claim
     resourceClaimTemplateName: timeslicing-gpu-template
   nodeSelector:
-    NodeGroupType: "gpu-dra"
+    node-type: "gpu-dra"
     nvidia.com/gpu.present: "true"
   tolerations:
   - key: nvidia.com/gpu
@@ -1029,7 +1029,7 @@ spec:
   - name: shared-gpu-claim-2
     resourceClaimTemplateName: timeslicing-gpu-template
   nodeSelector:
-    NodeGroupType: "gpu-dra"
+    node-type: "gpu-dra"
     nvidia.com/gpu.present: "true"
   tolerations:
   - key: nvidia.com/gpu
@@ -1241,7 +1241,7 @@ spec:
     resourceClaimTemplateName: mps-gpu-template
   
   nodeSelector:
-    NodeGroupType: "gpu-dra"
+    node-type: "gpu-dra"
     nvidia.com/gpu.present: "true"
   tolerations:
   - key: nvidia.com/gpu

--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -490,6 +490,13 @@ metadata:
   version: '1.33'
 
 managedNodeGroups:
+  - name: base-nodes
+    amiFamily: AmazonLinux2023
+    instanceType: m5.xlarge
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 2
+
 - name: gpu-dra-nodes
   amiFamily: AmazonLinux2023
   instanceType: g6.12xlarge

--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -523,7 +523,7 @@ Deploy the NVIDIA device plugin to enable basic GPU discovery:
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm repo add nvidia https://nvidia.github.io/k8s-device-plugin
+helm repo add nvidia-device-plugin https://nvidia.github.io/k8s-device-plugin
 helm repo update
 ----
 
@@ -547,7 +547,7 @@ EOF
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm install nvidia-device-plugin nvidia/nvidia-device-plugin \
+helm install nvidia-device-plugin nvidia-device-plugin/nvidia-device-plugin \
  --namespace nvidia-device-plugin \
  --create-namespace \
  --version v0.17.1 \
@@ -597,7 +597,7 @@ kubeletPlugin:
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+helm repo add nvidia-ngc https://helm.ngc.nvidia.com/nvidia
 helm repo update
 ----
 
@@ -605,7 +605,7 @@ helm repo update
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+helm install nvidia-dra-driver nvidia-ngc/nvidia-dra-driver-gpu \
  --version="25.3.0-rc.2" \
  --namespace nvidia-dra-driver \
  --create-namespace \
@@ -1366,7 +1366,7 @@ and dynamic resource allocation capabilities.
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm repo add nvidia https://nvidia.github.io/gpu-operator
+helm repo add nvidia-gpu-operator https://nvidia.github.io/gpu-operator
 helm repo update
 ----
 
@@ -1472,7 +1472,7 @@ daemonsets:
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm install gpu-operator nvidia/gpu-operator \
+helm install gpu-operator nvidia-gpu-operator/gpu-operator \
   --namespace gpu-operator \
   --create-namespace \
   --version v25.3.1 \

--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -517,6 +517,25 @@ eksctl create cluster -f dra-eks-cluster.yaml
 [#aiml-dra-nvidia-plugin]
 ==== Step 2: Deploy the NVIDIA device plugin
 
+When you create a cluster using eksctl, the device plugin service is automatically installed in the kube-system namespace.
+
+. Verify that the NVIDIA device plugin service are available:
++
+[source,bash,subs="verbatim,attributes"]
+----
+kubectl get po -n kube-system | grep nvidia-device-plugin-daemonset
+----
++
+The following is the expected output:
++
+[source,bash,subs="verbatim,attributes",role="nocopy"]
+----
+kube-system   nvidia-device-plugin-daemonset-2s6pv   1/1     Running   0          7m8s
+kube-system   nvidia-device-plugin-daemonset-8zhq8   1/1     Running   0          7m8s
+----
+
+If you find that the device plugin service is not automatically installed, please follow the steps below to deploy it.
+
 Deploy the NVIDIA device plugin to enable basic GPU discovery:
 
 . Add the NVIDIA device plugin Helm repository:


### PR DESCRIPTION
In my actual reference documents, during the practise, I found the following problems:

1. Helm chart repository name conflict related to Nvidia

  ```
  helm repo add nvidia https://nvidia.github.io/k8s-device-plugin
  helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
  helm repo add nvidia https://nvidia.github.io/gpu-operator
  ```

> All helm repos are named nvidia, which causes repo name conflicts. Different repo names have been used to distinguish them.


2. Automatic installation instructions for the Nvidia device plugin service


3. pending issues of coredns and metrics-server services
  The Pod cannot be scheduled because the default gpu-dra-nodes adds taints:
  ```
  kube-system   coredns-7bf648ff5d-4bs45               0/1     Pending   0          12m
  kube-system   coredns-7bf648ff5d-n4bwq               0/1     Pending   0          12m
  kube-system   metrics-server-7fb96f5556-4cpdl        0/1     Pending   0          12m
  kube-system   metrics-server-7fb96f5556-6mbvh        0/1     Pending   0          12m
  ```

>   So a base-nodes NodeGroup was added to fix this problem.


4. Pod Pending issue caused by mismatch between Pod nodeSelector label and NodeGroup label key

> The Pod nodeSelector label is **NodeGroupType: gpu-dra**, but NodeGroup label is **node-type: "gpu-dra"**, so change the Pod nodeSelector label to **node-type: "gpu-dra"**.