### PR TITLE
Update VPC CNI documentation to rectify pod examples

### DIFF
--- a/latest/bpg/networking/vpc-cni.adoc
+++ b/latest/bpg/networking/vpc-cni.adoc
@@ -103,11 +103,7 @@ For Node 3:
 Total warm pool calculation:
 - 17 (Node 1) + 17 (Node 2) + 9 (Node 3) = 43 IPs
 
-Keep in mind that infrastructure pods, often running as daemon sets, each contribute to the max-pod count. These can include:
-
-* CoreDNS
-* Amazon Elastic LoadBalancer
-* Operational pods for metrics-server
+Keep in mind that infrastructure pods, often running as daemon sets, each contribute to the max-pod count. 
 
 We suggest that you plan your infrastructure by combining these Pods' capacities. For a list of the maximum number of Pods supported by each instance type, see https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni-max-pods.txt[eni-max-Pods.txt] on GitHub.
 


### PR DESCRIPTION
Removed specific examples of infrastructure pods contributing to max-pod count.

*Issue #, if available:*

*Description of changes:* The pod examples were referring to deployment based pods and not daemonset based pods. These examples are no where related to the maxPods issue. 
The context here is to explain the customers that daemonset pods (hostNetwork: true) pods can add to maxPods and they should plan their infra accordingly. (like kube-proxy, vpc-cni, ebs-csi-node etc)

Hence, I have removed the incorrect examples in this context


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
