### PR TITLE
Update cluster-autoscaler.adoc for node group balancing

### DIFF
--- a/latest/bpg/autoscaling/cluster-autoscaler.adoc
+++ b/latest/bpg/autoscaling/cluster-autoscaler.adoc
@@ -472,7 +472,7 @@ Machine learning distributed training jobs benefit significantly from
 the minimized latency of same-zone node configurations. These workloads
 deploy multiple pods to a specific zone. This can be achieved by setting
 Pod Affinity for all co-scheduled pods or Node Affinity using
-`topologyKey: failure-domain.beta.kubernetes.io/zone`. The Cluster
+`topologyKey: topology.kubernetes.io/zone`. The Cluster
 Autoscaler will then scale out a specific zone to match demands. You may
 wish to allocate multiple EC2 Auto Scaling Groups, one per availability
 zone to enable failover for the entire co-scheduled workload.

--- a/latest/bpg/autoscaling/cluster-autoscaler.adoc
+++ b/latest/bpg/autoscaling/cluster-autoscaler.adoc
@@ -480,7 +480,7 @@ zone to enable failover for the entire co-scheduled workload.
 Ensure that:
 
 * Node group balancing is enabled by setting
-`balance-similar-node-groups=false`
+`balance-similar-node-groups=true`
 * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[Node
 Affinity] and/or
 https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/[Pod


### PR DESCRIPTION
Co-Scheduling incorrectly says to set "Node group balancing is enabled by setting balance-similar-node-groups=false" - instead of false it should be true.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
