### PR TITLE
Update Subnet Calculator link to latest version

### DIFF
--- a/latest/bpg/networking/index.adoc
+++ b/latest/bpg/networking/index.adoc
@@ -64,7 +64,7 @@ EKS's support for IPv6 is focused on solving the IP exhaustion problem caused by
 
 == Subnet Calculator
 
-This project includes a https://github.com/aws/aws-eks-best-practices/blob/master/content/networking/subnet-calc/subnet-calc.xlsx[Subnet Calculator Excel Document]. This calculator document simulates the IP address consumption of a specified workload under different ENI configuration options, such as `WARM_IP_TARGET` and `WARM_ENI_TARGET`. The document includes two sheets, a first for Warm ENI mode, and a second for Warm IP mode. Review the xref:vpc-cni[VPC CNI guidance] for more information on these modes.
+This project includes a https://github.com/aws/aws-eks-best-practices/blob/master/latest/bpg/networking/subnet-calc/subnet-calc.xlsx[Subnet Calculator Excel Document]. This calculator document simulates the IP address consumption of a specified workload under different ENI configuration options, such as `WARM_IP_TARGET` and `WARM_ENI_TARGET`. The document includes two sheets, a first for Warm ENI mode, and a second for Warm IP mode. Review the xref:vpc-cni[VPC CNI guidance] for more information on these modes.
 
 Inputs:
 


### PR DESCRIPTION
Subnet Calculator link was broken. Fixed it.

*Issue #, if available:*

[Subnet Calculator Excel Document](https://github.com/aws/aws-eks-best-practices/blob/master/content/networking/subnet-calc/subnet-calc.xlsx) is throwing a 404 error.


*Description of changes:*

Fixed the same by editing the link

[Subnet Calculator Excel Document](https://github.com/aws/aws-eks-best-practices/blob/master/latest/bpg/networking/subnet-calc/subnet-calc.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
