### PR TITLE
fix: not showing YAML properly

### DIFF
--- a/latest/bpg/cost/cost_opt_compute.adoc
+++ b/latest/bpg/cost/cost_opt_compute.adoc
@@ -147,23 +147,23 @@ Node utilization is defined as the sum of requested resources divided by capacit
 
 You can prevent scale down from happening by ensuring that pods that are expensive to evict are protected by a label recognized by the Cluster Autoscaler. To do this, ensure that pods that are expensive to evict have the annotation `cluster-autoscaler.kubernetes.io/safe-to-evict=false`. Below is an example yaml to set the annotation:
 
-```yaml hl_lines="8"
+[,yaml]
+----
 apiVersion: v1
 kind: Pod
 metadata:
   name: label-demo
   labels:
     environment: production
-  annotations: +
-    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 spec:
   containers:
-
-* name: nginx
-image: nginx
-ports:
- ** containerPort: 80
-```
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+----
 
 === Tag nodes with Cluster Autoscaler and Karpenter
 

--- a/latest/bpg/cost/cost_opt_compute.adoc
+++ b/latest/bpg/cost/cost_opt_compute.adoc
@@ -123,23 +123,23 @@ spec:
 
 For workloads that might not be interruptible e.g. long running batch jobs without checkpointing, consider annotating pods with the `do-not-evict` annotation. By opting pods out of eviction, you are telling Karpenter that it should not voluntarily remove nodes containing this pod. However, if a `do-not-evict` pod is added to a node while the node is draining, the remaining pods will still evict, but that pod will block termination until it is removed. In either case, the node will be cordoned to prevent additional work from being scheduled on the node. Below is an example showing how set the annotation:
 
-```yaml hl_lines="8"
+[,yaml]
+----
 apiVersion: v1
 kind: Pod
 metadata:
   name: label-demo
   labels:
     environment: production
-  annotations: +
-    "karpenter.sh/do-not-evict": "true"
+  annotations:
+    karpenter.sh/do-not-evict: "true"
 spec:
   containers:
-
-* name: nginx
-image: nginx
-ports:
- ** containerPort: 80
-```
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+----
 
 === Remove under-utilized nodes by adjusting Cluster Autoscaler parameters
 


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/best-practices/cost-opt-compute.html Section Karpenter Consolidation holds an unformatted yaml.

*Issue #, if available:*

*Description of changes:*
Modifying the test being displayed wrongly to show the correct code. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
