### PR TITLE
fix: typo in cluster autoscaler docs

### DIFF
--- a/latest/bpg/autoscaling/cluster-autoscaler.adoc
+++ b/latest/bpg/autoscaling/cluster-autoscaler.adoc
@@ -85,8 +85,8 @@ https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudpro
 in your cluster. It uses
 https://en.wikipedia.org/wiki/Leader_election[leader election] to ensure
 high availability, but work is done by a single replica at a time. It is
-not horizontally scalable. For basic setups, the default it should work
-out of the box using the provided
+not horizontally scalable. For basic setups, the default should work out
+of the box using the provided
 https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html[installation
 instructions], but there are a few things to keep in mind.
 


### PR DESCRIPTION
*Issue #, if available:* Not available

*Description of changes:* Fix formatting and remove unnecessary word 'it' in the text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
