### PR TITLE
Add EKS workshop registration banner to documentation pages 

### DIFF
--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -10,6 +10,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
 
 == GPU Resource Optimization and Cost Management
 

--- a/latest/bpg/aiml/aiml_index.adoc
+++ b/latest/bpg/aiml/aiml_index.adoc
@@ -9,7 +9,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
-TIP: Visit https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=elthis[Get Hands on with EKS] to learn about upcoming Amazon EKS AI/ML events and workshops.
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
 
 Implementing best practices when running AI/ML workloads on EKS can ensure that those workloads are performant, cost-effective, resilient, and properly resourced.
 Best practices are divided into the following general sections: Compute, Networking, Storage, Observability, and Performance.

--- a/latest/bpg/aiml/aiml_networking.adoc
+++ b/latest/bpg/aiml/aiml_networking.adoc
@@ -10,6 +10,8 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 == Consider Higher Network Bandwidth or Elastic Fabric Adapter For Applications with High Inter-Node Communication
 
 For distributed training workloads on Amazon EKS with high inter-node communication demands, consider selecting instances with higher network bandwidth or https://docs.aws.amazon.com/eks/latest/userguide/node-efa.html[Elastic Fabric Adapter] (EFA). Insufficient network performance can bottleneck data transfer, slowing down machine learning tasks like distributed multi-GPU training. Note that inference workloads don't typically have high inter-node communication.

--- a/latest/bpg/aiml/aiml_observability.adoc
+++ b/latest/bpg/aiml/aiml_observability.adoc
@@ -10,6 +10,8 @@
 :authors: ["Leah Tucker", "Omri Shiv"]
 :date: 2025-11-19
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 == Monitoring and Observability
 
 [#gpu-metrics-explained]

--- a/latest/bpg/aiml/aiml_performance.adoc
+++ b/latest/bpg/aiml/aiml_performance.adoc
@@ -10,6 +10,8 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 == Managing ML Artifacts, Serving Frameworks, and Startup Optimization
 
 Deploying machine learning (ML) models on Amazon EKS requires thoughtful consideration of how models are integrated into container images and runtime environments. This ensures scalability, reproducibility, and efficient resource utilization. This topic describes the different approaches to handling ML model artifacts, selecting serving frameworks, and optimizing container startup times through techniques like pre-caching, all tailored to reduce container startup times.

--- a/latest/bpg/aiml/aiml_security.adoc
+++ b/latest/bpg/aiml/aiml_security.adoc
@@ -10,6 +10,8 @@
 :authors: ["Leah Tucker"]
 :date: 2025-07-01
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 == Security and Compliance
 
 === Consider S3 with KMS for encryption-compliant storage

--- a/latest/bpg/aiml/aiml_storage.adoc
+++ b/latest/bpg/aiml/aiml_storage.adoc
@@ -10,6 +10,8 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 == Data Management and Storage
 
 === Deploy AI Models to Pods Using a CSI Driver

--- a/latest/bpg/autoscaling/auto-mode.adoc
+++ b/latest/bpg/autoscaling/auto-mode.adoc
@@ -7,7 +7,7 @@
 :info_titleabbrev: EKS Auto Mode
 :imagesdir: images/autoscaling
 
-TIP: Interested in gaining hands-on experience with Amazon EKS Auto Mode? Join an upcoming virtual Kubernetes workshop led by AWS experts by signing up on https://aws-experience.com/emea/smb/events/series/simplifying-kubernetes-operations-with-amazon-eks-auto-mode?trk=e3d0398c-e0e9-4665-af82-a2e8124a6db8[AWS Connected Community].
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
 
 Amazon EKS Auto Mode represents a significant evolution in Kubernetes infrastructure management, combining secure and scalable cluster infrastructure with integrated Kubernetes capabilities managed by AWS . The service provides fully-managed worker node operations, eliminating the need for customers to set up Managed Node Groups or AutoScaling groups . 
 

--- a/latest/bpg/autoscaling/cluster-autoscaler.adoc
+++ b/latest/bpg/autoscaling/cluster-autoscaler.adoc
@@ -9,6 +9,8 @@
 
 include::../attributes.txt[]
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 == Overview
 
 https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler[The

--- a/latest/bpg/autoscaling/karpenter.adoc
+++ b/latest/bpg/autoscaling/karpenter.adoc
@@ -7,6 +7,8 @@
 :info_titleabbrev: Karpenter
 :imagesdir: images/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 
 https://karpenter.sh/[Karpenter] is an open-source project designed to 
 enhance node lifecycle management within Kubernetes clusters. It automates

--- a/latest/bpg/index.adoc
+++ b/latest/bpg/index.adoc
@@ -20,6 +20,8 @@
 Learn best practices for operating EKS clusters.
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Welcome to the EKS Best Practices Guides. The primary goal of this
 project is to offer a set of best practices for day 2 operations for
 Amazon EKS. We elected to publish this guidance to GitHub so we could

--- a/latest/bpg/networking/custom-networking.adoc
+++ b/latest/bpg/networking/custom-networking.adoc
@@ -14,6 +14,8 @@
 Custom Networking
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 By default, Amazon VPC CNI will assign Pods an IP address selected from the primary subnet.  The primary subnet is the subnet CIDR that the primary ENI is attached to, usually the subnet of the node/host.
 
 If the subnet CIDR is too small, the CNI may not be able to acquire enough secondary IP addresses to assign to your Pods. This is a common challenge for EKS IPv4 clusters.

--- a/latest/bpg/networking/index.adoc
+++ b/latest/bpg/networking/index.adoc
@@ -20,6 +20,8 @@
 Learn best practices for cluster Networking.
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 It is critical to understand Kubernetes networking to operate your cluster and applications efficiently. Pod networking, also called the cluster networking, is the center of Kubernetes networking. Kubernetes supports https://github.com/containernetworking/cni[Container Network Interface] (CNI) plugins for cluster networking.
 
 Amazon EKS officially supports https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html[Amazon Virtual Private Cloud (VPC)] CNI plugin to implement Kubernetes Pod networking. The VPC CNI provides native integration with AWS VPC and works in underlay mode. In underlay mode, Pods and hosts are located at the same network layer and share the network namespace. The IP address of the Pod is consistent from the cluster and VPC perspective.

--- a/latest/bpg/networking/ip-optimization-strategies.adoc
+++ b/latest/bpg/networking/ip-optimization-strategies.adoc
@@ -5,6 +5,8 @@
 :imagesdir: images/networking/
 :info_doctype: section
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Containerized environments are growing in scale at a rapid pace, thanks to application modernization. This means that more and more worker nodes and pods are being deployed.
 
 The xref:vpc-cni[Amazon VPC CNI] plugin assigns each pod an IP address from the VPC's CIDR(s). This approach provides full visibility of the Pod addresses with tools such as VPC Flow Logs and other monitoring solutions. Depending on your workload type this can cause a substantial number of IP addresses to be consumed by the pods.

--- a/latest/bpg/networking/loadbalancing.adoc
+++ b/latest/bpg/networking/loadbalancing.adoc
@@ -8,6 +8,8 @@
 
 
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Load Balancers receive incoming traffic and distribute it across targets
 of the intended application hosted in an EKS Cluster. This improves the
 resilience of the application. When deployed in an EKS Cluster the

--- a/latest/bpg/networking/prefix-mode_linux.adoc
+++ b/latest/bpg/networking/prefix-mode_linux.adoc
@@ -13,6 +13,7 @@
 Prefix Mode for Linux
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
 
 Amazon VPC CNI assigns network prefixes to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html[Amazon EC2 network interfaces] to increase the number of IP addresses available to nodes and increase pod density per node. You can configure version 1.9.0 or later of the Amazon VPC CNI add-on to assign IPv4 and IPv6 CIDRs instead of assigning individual secondary IP addresses to network interfaces.
 

--- a/latest/bpg/networking/sgpp.adoc
+++ b/latest/bpg/networking/sgpp.adoc
@@ -13,7 +13,7 @@
 Security Groups Per Pod
 --
 
-
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
 
 An AWS security group acts as a virtual firewall for EC2 instances to control inbound and outbound traffic. By default, the Amazon VPC CNI will use security groups associated with the primary ENI on the node. More specifically, every ENI associated with the instance will have the same EC2 Security Groups. Thus, every Pod on a node shares the same security groups as the node it runs on.
 

--- a/latest/bpg/networking/subnets.adoc
+++ b/latest/bpg/networking/subnets.adoc
@@ -13,6 +13,8 @@
 VPC and Subnet Considerations
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Operating an EKS cluster requires knowledge of AWS VPC networking, in addition to Kubernetes networking.
 
 We recommend you understand the EKS control plane communication mechanisms before you start designing your VPC or deploying clusters into existing VPCs.

--- a/latest/bpg/networking/vpc-cni.adoc
+++ b/latest/bpg/networking/vpc-cni.adoc
@@ -13,6 +13,8 @@
 Amazon VPC CNI
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 video::RBE3yk2UlYA[youtube,height = 390,width = 480]
 
 Amazon EKS implements cluster networking through the https://github.com/aws/amazon-vpc-cni-k8s[Amazon VPC Container Network Interface] plugin, also known as VPC CNI. The CNI plugin allows Kubernetes Pods to have the same IP address as they do on the VPC network. More specifically, all containers inside the Pod share a network namespace, and they can communicate with each-other using local ports.

--- a/latest/bpg/reliability/controlplane.adoc
+++ b/latest/bpg/reliability/controlplane.adoc
@@ -9,6 +9,8 @@
 :idprefix: reliability-cp
 
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Amazon Elastic Kubernetes Service (EKS) is a managed Kubernetes service
 that makes it easy for you to run Kubernetes on AWS without needing to
 install, operate, and maintain your own Kubernetes control plane or

--- a/latest/bpg/scalability/control-plane.adoc
+++ b/latest/bpg/scalability/control-plane.adoc
@@ -5,6 +5,8 @@
 :info_titleabbrev: Control Plane
 :imagesdir: images/scalability/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 The Kubernetes control plane consists of the Kubernetes API Server, Kubernetes Controller Manager, Scheduler and other components that are required for Kubernetes to function. Scalability limits of these components are different depending on what you're running in the cluster, but the areas with the biggest impact to scaling include the Kubernetes version, utilization, and individual Node scaling.
 
 == Limit workload and node bursting

--- a/latest/bpg/scalability/index.adoc
+++ b/latest/bpg/scalability/index.adoc
@@ -4,6 +4,8 @@
 :info_titleabbrev: Scalability
 :imagesdir: images/scalability/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 This guide provides advice for scaling EKS clusters. The goal of scaling an EKS cluster is to maximize the amount of work a single cluster can perform. Using a single, large EKS cluster can reduce operational load compared to using multiple clusters, but it has trade-offs for things like multi-region deployments, tenant isolation, and cluster upgrades. In this document we will focus on how to achieve maximum scalability with a single cluster.
 
 == How to use this guide

--- a/latest/bpg/scalability/quotas.adoc
+++ b/latest/bpg/scalability/quotas.adoc
@@ -3,6 +3,8 @@
 :info_doctype: section
 :imagesdir: images/scalability/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Amazon EKS can be used for a variety of workloads and can interact with a wide range of AWS services, and we have seen customer workloads encounter a similar range of AWS service quotas and other issues that hamper scalability.
 
 Your AWS account has default quotas (an upper limit on the number of each AWS resource your team can request). Each AWS service defines their own quota, and quotas are generally region-specific. You can request increases for some quotas (soft limits), and other quotas cannot be increased (hard limits). You should consider these values when architecting your applications. Consider reviewing these service limits periodically and incorporate them during in your application design.

--- a/latest/bpg/security/detective.adoc
+++ b/latest/bpg/security/detective.adoc
@@ -8,6 +8,8 @@
 :info_titleabbrev: Detective Controls
 :imagesdir: images/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Collecting and analyzing [audit] logs is useful for a variety of
 different reasons. Logs can help with root cause analysis and
 attribution, i.e. ascribing a change to a particular user. When enough

--- a/latest/bpg/security/iam.adoc
+++ b/latest/bpg/security/iam.adoc
@@ -10,6 +10,8 @@
 
 include::../attributes.txt[]
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html[Identity
 and Access Management] (IAM) is an AWS service that performs two
 essential functions: Authentication and Authorization. Authentication

--- a/latest/bpg/security/index.adoc
+++ b/latest/bpg/security/index.adoc
@@ -15,6 +15,8 @@
 :info_titleabbrev: Security
 :imagesdir: images/security/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 This guide provides advice about protecting information, systems, and
 assets that are reliant on EKS while delivering business value through
 risk assessments and mitigation strategies. The guidance herein is part

--- a/latest/bpg/security/network.adoc
+++ b/latest/bpg/security/network.adoc
@@ -10,6 +10,8 @@
 
 include::../attributes.txt[]
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 Network security has several facets. The first involves the application
 of rules which restrict the flow of network traffic between services.
 The second involves the encryption of traffic while it is in transit.

--- a/latest/bpg/security/pods.adoc
+++ b/latest/bpg/security/pods.adoc
@@ -8,6 +8,8 @@
 :info_titleabbrev: Pod Security
 :imagesdir: images/
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 The pod specification includes a variety of different attributes that
 can strengthen or weaken your overall security posture. As a Kubernetes
 practitioner your chief concern should be preventing a process that's

--- a/latest/bpg/upgrades/index.adoc
+++ b/latest/bpg/upgrades/index.adoc
@@ -23,6 +23,8 @@ include::../attributes.txt[]
 Learn best practices for cluster upgrades.
 --
 
+TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+
 This guide shows cluster administrators how to plan and execute their
 Amazon EKS upgrade strategy. It also describes how to upgrade
 self-managed nodes, managed node groups, Karpenter nodes, and Fargate


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added workshop registration banner to key EKS documentation pages to promote upcoming Amazon EKS workshops.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.