### PR TITLE
docs(scalability): fix automountServiceAccountToken example value

### DIFF
--- a/latest/bpg/scalability/workloads.adoc
+++ b/latest/bpg/scalability/workloads.adoc
@@ -62,7 +62,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: app
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 ----
 
 Monitor the number of secrets in the cluster before it exceeds the limit of 10,000. You can see a total count of secrets in a cluster with the following command. You should monitor this limit through your cluster monitoring tooling.


### PR DESCRIPTION
## Summary

- Fix incorrect `automountServiceAccountToken` value in the ServiceAccount YAML example
- The documentation text correctly recommends setting this to `false` for applications that don't need Kubernetes resource access, but the example YAML showed `true`

## Changes

- Changed `automountServiceAccountToken: true` to `automountServiceAccountToken: false` in the ServiceAccount example

## Test plan

- [x] Verified the fix matches the documented recommendation
- [x] Verified no other instances need updating in this file

Fixes #634

---
Generated with [Claude Code](https://claude.ai/code)