### PR TITLE
Fix mathematical expression formatting in documentation

### DIFF
--- a/latest/bpg/networking/custom-networking.adoc
+++ b/latest/bpg/networking/custom-networking.adoc
@@ -121,7 +121,7 @@ Consider the maximum number of Pods for an m5.large instance with custom network
 
 The maximum number of Pods you can run without prefix assignment is 29
 
-* `((3 ENIs - 1) * (10 secondary IPs per ENI - 1)) + 2 = 20`
+* `(((3 ENIs - 1) * (10 secondary IPs per ENI - 1)) + 2 = 20`
 
 Enabling prefix attachments increases the number of Pods to 290.
 


### PR DESCRIPTION
*Issue #, if available:* The Mathematical expression of calculating maximum number of pods we can run without prefix assignment was missing opening Parentheses.

*Description of changes:* added the Parentheses to the doc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
