### PR TITLE
update 'in' to 'an'

### DIFF
--- a/latest/bpg/reliability/controlplane.adoc
+++ b/latest/bpg/reliability/controlplane.adoc
@@ -35,7 +35,7 @@ VPC. The EKS control plane comprises the Kubernetes API server nodes,
 etcd cluster. Kubernetes API server nodes that run components like the
 API server, scheduler, and `kube-controller-manager` run in an
 auto-scaling group. EKS runs a minimum of two API server nodes in
-distinct Availability Zones (AZs) within in AWS region. Likewise, for
+distinct Availability Zones (AZs) within an AWS region. Likewise, for
 durability, the etcd server nodes also run in an auto-scaling group that
 spans three AZs. EKS runs a NAT Gateway in each AZ, and API servers and
 etcd servers run in a private subnet. This architecture ensures that an


### PR DESCRIPTION
*Description of changes:*
- Feels like a typo here, as 'in' is grammatically incorrect. The fix could be elsewhere though. I am unsure of the intent.
- The intent I was going for with 'an' as the fix could be more explicitly be stated as "within a single AWS region" if "within an AWS region" is too vague

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
