### PR TITLE
fix: remove 'v' prefix from nvidia-device-plugin helm chart version

### DIFF
--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -676,7 +676,7 @@ EOF
 helm install nvidia-device-plugin nvidia/nvidia-device-plugin \
  --namespace nvidia-device-plugin \
  --create-namespace \
- --version v0.17.1 \
+ --version 0.17.1 \
  --values nvidia-device-plugin-values.yaml
 ----
 


### PR DESCRIPTION
## Summary

Fixes #720

The helm chart version for `nvidia-device-plugin` uses `v0.17.1` but the NVIDIA helm repo doesn't use the `v` prefix for chart versions. This causes `helm install` to fail with:

```
Error: INSTALLATION FAILED: chart "nvidia-device-plugin" matching v0.17.1 not found in nvidia index.
```

## Changes

Removed the `v` prefix from the `--version` flag in the helm install command (`v0.17.1` → `0.17.1`) in `latest/bpg/aiml/aiml_compute.adoc`.