### PR TITLE
docs(aiml): Update workshop TIP link and add to CPU inference

### DIFF
--- a/latest/bpg/aiml/aiml_compute.adoc
+++ b/latest/bpg/aiml/aiml_compute.adoc
@@ -10,7 +10,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 == GPU Resource Optimization and Cost Management
 

--- a/latest/bpg/aiml/aiml_cpu_inference.adoc
+++ b/latest/bpg/aiml/aiml_cpu_inference.adoc
@@ -10,6 +10,8 @@
 :authors: ["Christian Melendez"]
 :date: 2026-04-20
 
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
+
 == Overview
 
 CPU instances are a first-class compute option for a wide range of AI workloads on Amazon EKS. From small language models (SLMs) and classical ML inference to data pipelines and agent orchestration, CPUs offer strong price-performance, broad capacity availability, and familiar Kubernetes scheduling semantics.

--- a/latest/bpg/aiml/aiml_index.adoc
+++ b/latest/bpg/aiml/aiml_index.adoc
@@ -9,7 +9,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 Implementing best practices when running AI/ML workloads on EKS can ensure that those workloads are performant, cost-effective, resilient, and properly resourced.
 Best practices are divided into the following general sections: Compute, Networking, Storage, Observability, and Performance.

--- a/latest/bpg/aiml/aiml_networking.adoc
+++ b/latest/bpg/aiml/aiml_networking.adoc
@@ -10,7 +10,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 == Consider Higher Network Bandwidth or Elastic Fabric Adapter For Applications with High Inter-Node Communication
 

--- a/latest/bpg/aiml/aiml_observability.adoc
+++ b/latest/bpg/aiml/aiml_observability.adoc
@@ -10,7 +10,7 @@
 :authors: ["Leah Tucker", "Omri Shiv"]
 :date: 2025-11-19
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 == Monitoring and Observability
 

--- a/latest/bpg/aiml/aiml_performance.adoc
+++ b/latest/bpg/aiml/aiml_performance.adoc
@@ -10,7 +10,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 == Managing ML Artifacts, Serving Frameworks, and Startup Optimization
 

--- a/latest/bpg/aiml/aiml_security.adoc
+++ b/latest/bpg/aiml/aiml_security.adoc
@@ -10,7 +10,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-07-01
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 == Security and Compliance
 

--- a/latest/bpg/aiml/aiml_storage.adoc
+++ b/latest/bpg/aiml/aiml_storage.adoc
@@ -10,7 +10,7 @@
 :authors: ["Leah Tucker"]
 :date: 2025-05-30
 
-TIP: https://aws-experience.com/emea/smb/events/series/get-hands-on-with-amazon-eks?trk=4a9b4147-2490-4c63-bc9f-f8a84b122c8c&sc_channel=el[Explore] best practices through Amazon EKS workshops.
+TIP: https://events.eksworkshop.com/workshops/genai/[Register] for upcoming Amazon EKS AI/ML workshops.
 
 == Data Management and Storage
 


### PR DESCRIPTION
Update the workshop TIP link across all AI/ML best practices pages to point to the EKS GenAI workshop and reword the link text to match the user guide. Add the missing TIP block to the CPU inference page so the callout is consistent across the section.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
