### PR TITLE
fix: typo in log-level snippet for Bottlerocket

### DIFF
--- a/latest/bpg/cost/cost_opt_observability.adoc
+++ b/latest/bpg/cost/cost_opt_observability.adoc
@@ -122,7 +122,7 @@ You can fine tune various Kubernetes components log levels. For example, if you 
 
 ----
 [settings.kubernetes]
-log-level = "2"
+log-level = 2
 image-gc-high-threshold-percent = "85"
 image-gc-low-threshold-percent = "80"
 ----


### PR DESCRIPTION
Update the code snippet for setting log-level in Bottlerocket userdata. The existing snippet is invalid and causes nodes to not join the cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
